### PR TITLE
feat: Amazon Polly TTS音声読み上げ＋リップシンク復活

### DIFF
--- a/.kiro/specs/tts-polly-lipsync/design.md
+++ b/.kiro/specs/tts-polly-lipsync/design.md
@@ -1,0 +1,474 @@
+# Design Document: TTS Polly LipSync
+
+## Overview
+
+**Purpose**: AI応答テキストをAmazon Pollyで音声合成し、VRMモデルのリップシンクと連動させることで、テキストのみの対話から音声付きの対話体験にアップグレードする。
+
+**Users**: Tonariを利用するすべてのユーザー。設定画面から音声出力のON/OFFを選択できる。
+
+**Impact**: 無効化されていた音声再生インフラ（LipSync, SpeakQueue）を再有効化し、TTS Lambda + API Gatewayを新規追加する。既存のテキストベース口パクは音声OFF時にそのまま維持。
+
+### Goals
+- Amazon Pollyによる日本語ニューラル音声合成（Kazuha, PCM16 16kHz）
+- 感情に応じたSSML prosody制御（6種の感情対応）
+- 音声波形の音量解析によるリアルタイムリップシンク
+- SpeakQueueによるキュー管理でスムーズな連続再生
+- 設定画面から音声ON/OFFを切り替え可能（デフォルトOFF、永続化）
+- 既存のCognito M2M認証を活用（新規IAMアクセスキー不要）
+
+### Non-Goals
+- 多言語音声対応（日本語のみ）
+- 複数の音声キャラクター選択機能
+- 音声ストリーミング再生（文単位のバッチ処理で十分）
+- 音声入力（STT）機能
+
+## Architecture
+
+### Existing Architecture Analysis
+
+現在の音声パイプラインは以下の状態：
+- `LipSync`クラス（`src/features/lipSync/lipSync.ts`）: Web Audio APIベースの音声再生・音量解析が完全実装済み。PCM16対応。未使用状態
+- `SpeakQueue`（`src/features/messages/speakQueue.ts`）: Singletonキュー管理。`model.speak()`呼び出しが完備。未使用状態
+- `speakCharacter`（`src/features/messages/speakCharacter.ts`）: テキストベースの母音リップシンクのみ稼働中。音声再生なし
+- `Model.speak()`（`src/features/vrmViewer/model.ts`）: 感情設定のみ実行。音声再生無効化済み
+
+既存のAWSインフラパターン：
+- CDKスタック（`infra/lib/tonari-stack.ts`）: Lambda + API Gateway + Lambda Authorizer (Cognito M2M)
+- フロントエンドからの呼び出し: Next.js API Route → `getCognitoToken()` → API Gateway
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+sequenceDiagram
+    participant H as handlers.ts
+    participant SC as speakCharacter
+    participant NX as /api/tts Next.js
+    participant CG as Cognito M2M
+    participant AG as API Gateway
+    participant TL as TTS Lambda
+    participant Polly as Amazon Polly
+    participant SQ as SpeakQueue
+    participant M as Model
+    participant LS as LipSync
+    participant VRM as VRM Avatar
+
+    H->>SC: speakCharacter(sessionId, talk, onStart, onComplete)
+    alt voiceEnabled = ON
+        SC->>SC: onStart()
+        SC->>NX: POST {text, emotion}
+        NX->>CG: getCognitoToken()
+        CG-->>NX: M2M Token
+        NX->>AG: POST /tts + Authorization
+        AG->>TL: invoke
+        TL->>Polly: SynthesizeSpeech(SSML, PCM 16kHz)
+        Polly-->>TL: AudioStream
+        TL-->>AG: PCM16 binary (base64)
+        AG-->>NX: Response
+        NX-->>SC: ArrayBuffer
+        SC->>SQ: addTask({audioBuffer, talk, ...})
+        SQ->>M: speak(audioBuffer, talk, false)
+        M->>LS: playFromArrayBuffer(buffer, onEnded, false, 16000)
+        LS->>VRM: volume → lipSync aa
+        LS-->>M: onEnded
+        M-->>SQ: resolve
+        SQ->>SC: onComplete()
+    else voiceEnabled = OFF
+        SC->>VRM: テキストベース母音リップシンク
+    end
+```
+
+**Architecture Integration**:
+- Selected pattern: 既存のCDK Lambda + API Gateway + Cognito M2Mパターンを踏襲。TTS LambdaのIAMロールでPolly認証（アクセスキー不要）
+- Domain boundaries: Lambda（音声合成） / Next.js API Route（認証プロキシ） / speakCharacter（分岐ロジック） / Model（音声再生・リップシンク）
+- Existing patterns preserved: CDK Lambda pattern, Cognito M2M auth, Zustand persist store, handlers.ts→speakCharacter呼び出し
+- New components: TTS Lambda（CDK）、Next.js API Route（プロキシ）
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Frontend | Next.js 14 (Pages Router) | speakCharacter分岐、設定UI | 既存 |
+| API Proxy | Next.js API Route | Cognito認証+API Gatewayプロキシ | 新規 |
+| API Gateway | AWS API Gateway | TTS LambdaへのHTTPエンドポイント | CDK既存リソース拡張 |
+| Auth | Cognito M2M + Lambda Authorizer | API Gateway認証 | 既存・変更なし |
+| TTS | TTS Lambda (Python 3.12) + Amazon Polly | テキスト→PCM16音声変換 | CDK新規 |
+| Audio | Web Audio API (LipSync class) | 音声再生、音量解析 | 既存・未変更 |
+| State | Zustand (persist) | voiceEnabled設定の永続化 | 既存パターン拡張 |
+
+## System Flows
+
+上記Architecture Pattern & Boundary Mapのシーケンス図を参照。
+
+**Key Decisions**:
+- テキスト表示は即座に行い、音声再生は非同期で実行。ユーザーはテキストを先に読める
+- SpeakQueueが文の再生順序を保証。先行文の再生完了を待ってから次の文を再生
+- Stop時はSpeakQueue.stopAll()→model.stopSpeaking()→LipSync.stopCurrentPlayback()の連鎖で即座に停止
+- Cognito M2M認証はNext.js API Routeが担当。`getCognitoToken()`（`src/lib/cognito.ts`）を再利用
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | テキスト→PCM16音声変換 | TTS Lambda | API Contract | Main Sequence |
+| 1.2 | 日本語ニューラル音声 | TTS Lambda | - | - |
+| 1.3 | エラーレスポンス | TTS Lambda, Next.js API Route | API Contract | - |
+| 1.4 | APIキー非露出 | TTS Lambda (IAMロール認証) | - | - |
+| 2.1 | 感情別音声パラメータ | TTS Lambda | Service Interface | Main Sequence |
+| 2.2 | 6感情対応 | TTS Lambda | Service Interface | - |
+| 2.3 | 未知感情のフォールバック | TTS Lambda | Service Interface | - |
+| 3.1 | 音声リップシンク | Model (LipSync) | State Management | Main Sequence |
+| 3.2 | 再生完了時の口閉じ | Model (LipSync) | - | Main Sequence |
+| 3.3 | 音量連動の口開閉 | Model (LipSync) | - | - |
+| 4.1 | 順序維持再生 | SpeakQueue (既存) | - | Main Sequence |
+| 4.2 | Stop機能 | SpeakQueue (既存) | - | - |
+| 4.3 | セッション管理 | SpeakQueue (既存) | - | - |
+| 4.4 | 発話中状態保持 | SpeakQueue (既存) | State Management | - |
+| 5.1 | ON/OFFトグル | Settings UI | State Management | - |
+| 5.2 | デフォルトOFF | Settings Store | State Management | - |
+| 5.3 | 設定永続化 | Settings Store | State Management | - |
+| 5.4 | OFF時テキストリップシンク | speakCharacter | - | Alt Flow |
+| 5.5 | ON時音声リップシンク | speakCharacter | - | Main Flow |
+| 6.1 | API失敗時フォールバック | speakCharacter | - | Error Flow |
+| 6.2 | ネットワーク不安定時 | speakCharacter | - | Error Flow |
+| 6.3 | AutoPlay制約対応 | LipSync (既存) | - | - |
+
+## Components and Interfaces
+
+| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies | Contracts |
+|-----------|--------------|--------|--------------|-----------------|-----------|
+| TTS Lambda | Infra / Lambda | Polly音声合成 | 1.1-1.4, 2.1-2.3 | Amazon Polly (P0) | API |
+| Next.js TTS Route | Backend / API | 認証プロキシ | 1.3, 1.4 | Cognito (P0), API Gateway (P0) | API |
+| CDK Stack Extension | Infra / CDK | Lambda+API GW定義 | 1.4 | - | - |
+| Settings Store | State | voiceEnabled永続化 | 5.2, 5.3 | Zustand (P0) | State |
+| Model LipSync | Feature / VRM | 音声再生＋リップシンク | 3.1-3.3 | LipSync (P0), EmoteController (P1) | Service, State |
+| speakCharacter | Feature / Messages | 音声/テキスト分岐 | 5.4, 5.5, 6.1, 6.2 | TTS Route (P0), SpeakQueue (P0), Model (P0) | Service |
+| Settings UI | UI / Settings | 音声ON/OFFトグル | 5.1 | Settings Store (P0) | - |
+| LipSync | Feature / Audio | Web Audio再生・音量解析 | 3.1, 3.3, 6.3 | - | **既存・変更なし** |
+| SpeakQueue | Feature / Messages | キュー管理・Stop | 4.1-4.4 | Model (P0) | **既存・変更なし** |
+
+### Infra / Lambda
+
+#### TTS Lambda
+
+| Field | Detail |
+|-------|--------|
+| Intent | テキストと感情をAmazon Polly経由でPCM16音声に変換して返却する |
+| Requirements | 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3 |
+
+**Responsibilities & Constraints**
+- Amazon Polly SynthesizeSpeechの呼び出しとSSML生成を担当
+- LambdaのIAMロールでPolly認証（アクセスキー不要）
+- 1リクエスト = 1文の音声合成。レスポンスはbase64エンコードされたPCM16バイナリ
+
+**Dependencies**
+- External: Amazon Polly (boto3) — 音声合成 (P0)
+- Inbound: API Gateway — Lambda Authorizer経由のHTTPリクエスト (P0)
+
+**Contracts**: API [x]
+
+##### API Contract
+
+| Method | Endpoint | Request | Response | Errors |
+|--------|----------|---------|----------|--------|
+| POST | /tts (API Gateway) | TtsRequest JSON | TtsResponse JSON (base64 audio) | 400, 500 |
+
+```typescript
+// リクエスト（API Gateway → Lambda）
+interface TtsRequest {
+  text: string
+  emotion: string  // EmotionType
+}
+
+// レスポンス（Lambda → API Gateway）
+interface TtsResponse {
+  audio: string       // base64エンコードされたPCM16バイナリ
+  sampleRate: number  // 16000
+}
+```
+
+##### Service Interface
+
+```python
+# 感情→SSMLパラメータのマッピング (Lambda内部)
+PROSODY_MAP = {
+    "happy":     {"rate": "105%", "pitch": "+5%"},
+    "angry":     {"rate": "110%", "pitch": "-5%", "volume": "loud"},
+    "sad":       {"rate": "85%",  "pitch": "-10%", "volume": "soft"},
+    "surprised": {"rate": "115%", "pitch": "+15%"},
+    "relaxed":   {"rate": "90%",  "pitch": "-3%"},
+    "neutral":   {}  # prosody調整なし
+}
+# 未知の感情 → neutralとして処理
+```
+
+- Preconditions: textが空でないこと
+- Postconditions: base64エンコードされたPCM16 16kHzバイナリが返却される
+- Invariants: SSMLのXML特殊文字（`<>&"'`）がエスケープされる
+
+**Implementation Notes**
+- ファイルパス: `infra/lambda/tts/index.py`
+- Python 3.12, boto3（Lambda標準ランタイムに含まれる）
+- Polly SynthesizeSpeech パラメータ: `Engine='neural'`, `VoiceId='Kazuha'`, `LanguageCode='ja-JP'`, `OutputFormat='pcm'`, `SampleRate='16000'`
+- レスポンスは `base64.b64encode(AudioStream.read())` でエンコード
+
+#### CDK Stack Extension
+
+| Field | Detail |
+|-------|--------|
+| Intent | TTS Lambda + API Gatewayエンドポイントをインフラに追加する |
+| Requirements | 1.4 |
+
+**Implementation Notes**
+- ファイルパス: `infra/lib/tonari-stack.ts`
+- 既存のPythonFunction + API Gatewayパターンを踏襲
+- IAMポリシー: `polly:SynthesizeSpeech` のみ
+- API Gateway: 既存の `crudApi` に `/tts` リソースを追加し、既存の `lambdaAuthorizer` で保護
+- CfnOutput: `TtsApiEndpoint` を出力
+
+### Backend / API
+
+#### Next.js TTS Route
+
+| Field | Detail |
+|-------|--------|
+| Intent | Cognito M2Mトークンを取得してAPI Gatewayにプロキシする |
+| Requirements | 1.3, 1.4 |
+
+**Responsibilities & Constraints**
+- `getCognitoToken()` でM2Mトークンを取得
+- API Gateway の `/tts` エンドポイントにリクエストをプロキシ
+- レスポンスのbase64をデコードしてArrayBufferとしてクライアントに返却
+
+**Dependencies**
+- Outbound: Cognito (`src/lib/cognito.ts`) — M2Mトークン取得 (P0)
+- Outbound: API Gateway — TTS Lambda呼び出し (P0)
+
+**Contracts**: API [x]
+
+##### API Contract
+
+| Method | Endpoint | Request | Response | Errors |
+|--------|----------|---------|----------|--------|
+| POST | /api/tts | TtsRequest JSON | PCM16 ArrayBuffer (audio/pcm) | 400, 500 |
+
+```typescript
+// クライアント → Next.js API Route
+interface TtsRequest {
+  text: string
+  emotion: EmotionType
+}
+```
+
+Response: `Content-Type: audio/pcm`, body は PCM16 16kHz バイナリ（base64デコード済み）
+
+**Implementation Notes**
+- ファイルパス: `src/pages/api/tts.ts`
+- API Gateway URLは環境変数 `PERFUME_API_URL` から取得（既存のAPI Gatewayと同じベースURL）
+- `getCognitoToken()` を `src/lib/cognito.ts` から再利用
+- レスポンスの `audio` フィールド (base64) を `Buffer.from(audio, 'base64')` でデコードして返却
+
+### State / Settings
+
+#### Settings Store Extension
+
+| Field | Detail |
+|-------|--------|
+| Intent | voiceEnabled設定をZustandストアに追加し永続化する |
+| Requirements | 5.2, 5.3 |
+
+**Contracts**: State [x]
+
+##### State Management
+
+```typescript
+// General interfaceに追加
+interface General {
+  // ... 既存フィールド
+  voiceEnabled: boolean
+}
+```
+
+- State model: `voiceEnabled: boolean`（デフォルト: `false`）
+- Persistence: `partialize`に`voiceEnabled: state.voiceEnabled`を追加
+- ファイルパス: `src/features/stores/settings.ts`
+
+### Feature / VRM
+
+#### Model LipSync Restoration
+
+| Field | Detail |
+|-------|--------|
+| Intent | LipSyncクラスを統合し、音声再生とリアルタイムリップシンクを実現する |
+| Requirements | 3.1, 3.2, 3.3 |
+
+**Responsibilities & Constraints**
+- LipSyncインスタンスの遅延初期化（音声ON時に初めて作成）
+- speak()でPromiseを返し、SpeakQueueの順次処理に対応
+- update()ループでLipSync音量→EmoteController lipSync('aa', volume)を駆動
+
+**Dependencies**
+- Inbound: SpeakQueue — speak()呼び出し (P0)
+- Outbound: LipSync — 音声再生・音量解析 (P0)
+- Outbound: EmoteController — lipSync('aa', volume)呼び出し (P1)
+
+**Contracts**: Service [x] / State [x]
+
+##### Service Interface
+
+```typescript
+class Model {
+  // 遅延初期化: 初回呼び出し時にAudioContextとLipSyncを作成
+  initLipSync(): void
+
+  // 音声再生（SpeakQueueから呼ばれる）
+  // 音声再生完了までawait可能なPromiseを返す
+  speak(buffer: ArrayBuffer, talk: Talk, isNeedDecode: boolean): Promise<void>
+
+  // 再生停止
+  stopSpeaking(): void
+}
+```
+
+- Preconditions: VRMモデルがロード済み
+- Postconditions: speak()完了後、口が閉じた状態に戻る
+
+##### State Management
+
+- `private _lipSync: LipSync | undefined` — 遅延初期化
+- update()内: `_lipSync?.update()` → volume取得 → `emoteController.lipSync('aa', volume)`
+- ファイルパス: `src/features/vrmViewer/model.ts`
+
+### Feature / Messages
+
+#### speakCharacter (分岐ロジック)
+
+| Field | Detail |
+|-------|--------|
+| Intent | voiceEnabled設定に基づき、音声パスとテキストパスを分岐する |
+| Requirements | 5.4, 5.5, 6.1, 6.2 |
+
+**Responsibilities & Constraints**
+- voiceEnabled=OFF: 既存のテキストベース母音リップシンク（変更なし）
+- voiceEnabled=ON: /api/tts呼び出し→SpeakQueueへキュー追加
+- APIエラー時はテキストベースリップシンクにフォールバック
+
+**Dependencies**
+- Inbound: handlers.ts — speakCharacter()呼び出し (P0)
+- Outbound: Next.js TTS Route — 音声合成 (P0)
+- Outbound: SpeakQueue — キュー管理 (P0)
+- Outbound: Model — initLipSync() (P1)
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```typescript
+// 既存のシグネチャを維持（handlers.tsの変更不要）
+function speakCharacter(
+  sessionId: string,
+  talk: Talk,
+  onStart?: () => void,
+  onComplete?: () => void
+): void
+```
+
+- Preconditions: なし（voiceEnabled設定を内部で参照）
+- Postconditions: 音声再生またはテキストリップシンクが完了した時点でonComplete()が呼ばれる
+
+**Implementation Notes**
+- 音声パス: onStart()を即座に呼び出し → fetch('/api/tts') → SpeakQueue.addTask() → onCompleteはSpeakQueueのタスク完了時
+- フォールバック: fetch失敗時は既存のテキストベース処理を実行
+- ファイルパス: `src/features/messages/speakCharacter.ts`
+
+### UI / Settings
+
+#### Settings UI Toggle
+
+| Field | Detail |
+|-------|--------|
+| Intent | 音声出力ON/OFFトグルを設定画面に追加する |
+| Requirements | 5.1 |
+
+**Implementation Notes**
+- ShowControlPanelセクションの後に配置
+- 既存のTextButtonトグルパターンに準拠: `settingsStore.setState((s) => ({ voiceEnabled: !s.voiceEnabled }))`
+- 翻訳キー追加: ja `"VoiceOutput": "音声出力"`, en `"VoiceOutput": "Voice Output"`
+- ファイルパス: `src/components/settings/based.tsx`
+- 翻訳ファイル: `locales/ja/translation.json`, `locales/en/translation.json`
+
+## Data Models
+
+### Data Contracts & Integration
+
+**API Data Transfer (Lambda)**
+
+TTS Lambdaリクエスト:
+```json
+{
+  "text": "こんにちは",
+  "emotion": "happy"
+}
+```
+
+TTS Lambdaレスポンス:
+```json
+{
+  "audio": "<base64 encoded PCM16 binary>",
+  "sampleRate": 16000
+}
+```
+
+**Next.js TTS Route レスポンス（クライアント向け）**:
+- Content-Type: `audio/pcm`
+- Body: PCM16 signed 16-bit little-endian, mono, 16000Hz (base64デコード済みバイナリ)
+
+**SpeakQueue タスク（既存）**:
+```typescript
+type SpeakTask = {
+  sessionId: string
+  audioBuffer: ArrayBuffer  // PCM16バイナリ
+  talk: Talk
+  isNeedDecode: boolean     // false（PCM16直接再生）
+  onComplete?: () => void
+}
+```
+
+## Error Handling
+
+### Error Categories and Responses
+
+**User Errors (400)**:
+- 空テキスト → Lambda: `{ error: "Text is required" }` (400)
+- 不正なリクエストボディ → Next.js Route: `{ error: "Invalid request" }` (400)
+
+**System Errors (500)**:
+- Polly API呼び出し失敗 → Lambda: `{ error: "TTS synthesis failed" }` (500)
+- Cognito認証失敗 → Next.js Route: `{ error: "Authentication failed" }` (500)
+- API Gateway到達不可 → Next.js Route: `{ error: "TTS service unavailable" }` (500)
+
+**Client-side エラー対応**:
+- fetch失敗 → テキストベースリップシンクにフォールバック（ユーザーへのエラー表示なし）
+- AudioContext制約 → LipSyncクラスのpendingPlaybacksキューで自動対応
+
+## Testing Strategy
+
+### Unit Tests
+- TTS Lambda: 感情→SSML prosodyマッピングの正確性
+- TTS Lambda: XML特殊文字エスケープ
+- TTS Lambda: 空テキスト・不正リクエストのバリデーション
+
+### Integration Tests
+- speakCharacter: voiceEnabled=ON時にfetch→SpeakQueue→model.speak()フロー
+- speakCharacter: API失敗時のフォールバック動作
+
+### E2E Tests
+- 設定画面でvoiceEnabledをONにし、チャットメッセージを送信して音声が再生されることを確認
+- Stopボタンで音声が即座に停止することを確認
+- voiceEnabled=OFF切替後、テキストベースリップシンクが正常動作することを確認
+
+## Security Considerations
+
+- AWS認証はLambdaのIAMロールで管理。IAMアクセスキーの発行・管理は不要
+- API Gatewayは既存のLambda Authorizer (Cognito M2M) で保護
+- Next.js API Routeは `getCognitoToken()` でサーバーサイドのみからトークンを取得
+- SSMLインジェクション防止: ユーザー入力テキスト内のXML特殊文字（`<>&"'`）をLambda内でエスケープしてからSSMLに埋め込む

--- a/.kiro/specs/tts-polly-lipsync/requirements.md
+++ b/.kiro/specs/tts-polly-lipsync/requirements.md
@@ -1,0 +1,68 @@
+# Requirements Document
+
+## Project Description (Input)
+TTS機能：Amazon Pollyによる音声読み上げ＋リップシンク復活。Issue #32: 現在テキストのみで応答しているTonariに、Amazon Pollyを使った音声読み上げ機能を追加する。AITuber-kitベースのコードに無効化状態で残っている音声再生インフラ（LipSync, SpeakQueue）を再有効化し、Pollyで合成した音声でVRMモデルのリップシンクを連動させる。具体的には：(1) Amazon Polly APIルート（/api/tts）を新規作成し、PCM16形式で音声を返す (2) 感情に応じたSSML prosody変換（happy, sad, angry等）を実装 (3) LipSyncクラスを再有効化し、音声波形の音量解析でリップシンクを制御 (4) SpeakQueueによるキュー管理でスムーズな再生を実現 (5) 設定画面に音声ON/OFFトグルを追加し、OFFの場合は既存のテキストベース口パクを維持
+
+## Introduction
+
+TonariのAI応答にAmazon Pollyによる音声読み上げ機能を追加し、VRMモデルのリップシンクを音声波形と連動させる。既存のテキストベース口パクアニメーションを維持しつつ、ユーザーが設定で音声出力のON/OFFを切り替えられるようにする。
+
+## Requirements
+
+### Requirement 1: 音声合成API
+
+**Objective:** ユーザーとして、AIの応答テキストを日本語の自然な音声に変換する仕組みがほしい。テキストのみの対話から音声付きの対話にアップグレードするため。
+
+#### Acceptance Criteria
+1. When AIの応答テキストが送信された時, the TTS API shall テキストをPCM16形式の音声バイナリに変換して返却する
+2. The TTS API shall 日本語ニューラル音声を使用して自然な発話を生成する
+3. If テキストが空またはリクエストが不正な場合, the TTS API shall 適切なエラーレスポンスを返却する
+4. The TTS API shall サーバーサイドで音声合成を行い、APIキーをクライアントに露出しない
+
+### Requirement 2: 感情連動音声
+
+**Objective:** ユーザーとして、AIの感情に応じて声の抑揚が変化してほしい。感情表現が豊かで自然な対話体験を得るため。
+
+#### Acceptance Criteria
+1. When 感情タグ付きのテキストが送信された時, the TTS API shall 感情に応じた音声パラメータ（速度・ピッチ・音量）を適用して音声を生成する
+2. The TTS API shall happy, sad, angry, surprised, relaxed, neutralの感情に対応する
+3. If 未知の感情タグが指定された場合, the TTS API shall neutralとして処理する
+
+### Requirement 3: 音声リップシンク
+
+**Objective:** ユーザーとして、音声再生中にVRMモデルの口が音声に合わせて動いてほしい。視覚的に自然な対話体験を得るため。
+
+#### Acceptance Criteria
+1. While 音声が再生中の間, the VRM Model shall 音声波形の音量に連動して口の開閉アニメーションを実行する
+2. When 音声再生が完了した時, the VRM Model shall 口を閉じた状態に戻る
+3. The VRM Model shall 音量が小さい時は口をほぼ閉じ、音量が大きい時は口を大きく開ける
+
+### Requirement 4: 音声再生キュー管理
+
+**Objective:** ユーザーとして、複数の文からなるAI応答が順序通りスムーズに再生されてほしい。途切れや順序入れ替わりのない一貫した音声体験を得るため。
+
+#### Acceptance Criteria
+1. When 複数の文が順次生成された時, the 音声再生システム shall 文の生成順序を維持して順番に再生する
+2. When Stopボタンが押された時, the 音声再生システム shall 現在の再生を即座に停止し、キューに残る音声をすべて破棄する
+3. When 新しい会話セッションが開始された時, the 音声再生システム shall 前のセッションの残存キューを破棄する
+4. While 音声を再生中の間, the UIシステム shall 発話中であることを状態として保持する
+
+### Requirement 5: 音声出力設定
+
+**Objective:** ユーザーとして、音声出力のON/OFFを設定画面から切り替えたい。自分の好みや環境に応じて音声の有無を選べるようにするため。
+
+#### Acceptance Criteria
+1. The 設定画面 shall 音声出力のON/OFFトグルを提供する
+2. The 音声出力設定 shall デフォルトでOFFとする
+3. When 音声出力設定が変更された時, the 設定システム shall ブラウザに設定を永続化し、次回アクセス時に復元する
+4. While 音声出力がOFFの間, the 対話システム shall 既存のテキストベース口パクアニメーションを使用する
+5. While 音声出力がONの間, the 対話システム shall 音声合成APIを呼び出して音声を再生し、音声リップシンクを実行する
+
+### Requirement 6: エラーハンドリングとフォールバック
+
+**Objective:** ユーザーとして、音声合成に失敗した場合でも対話が中断されないでほしい。安定した対話体験を維持するため。
+
+#### Acceptance Criteria
+1. If 音声合成APIがエラーを返した場合, the 対話システム shall テキストベース口パクアニメーションにフォールバックする
+2. If ネットワーク接続が不安定な場合, the 対話システム shall テキスト表示は即座に行い、音声再生のみスキップする
+3. While ブラウザのAutoPlay制約により音声再生がブロックされている間, the 音声再生システム shall ユーザーの初回操作を検出して自動的に音声再生を開始する

--- a/.kiro/specs/tts-polly-lipsync/research.md
+++ b/.kiro/specs/tts-polly-lipsync/research.md
@@ -1,0 +1,93 @@
+# Research & Design Decisions
+
+## Summary
+- **Feature**: `tts-polly-lipsync`
+- **Discovery Scope**: Extension（既存の無効化された音声インフラの再有効化 + Amazon Polly統合）
+- **Key Findings**:
+  - Polly PCM出力は8kHz/16kHzのみ対応（24kHzはMP3/OGG限定）。PCM 16kHzを採用し、LipSyncクラスのsampleRateパラメータで対応
+  - SpeakQueueはmodel.speak()呼び出し・セッション管理・Stop機能が完備。変更不要
+  - AWS SDKは既にプロジェクトに3パッケージ導入済み。@aws-sdk/client-polly追加は既存パターンに合致
+
+## Research Log
+
+### Amazon Polly Kazuha音声の仕様
+- **Context**: TTS音声としてKazuhaを選定。仕様確認が必要
+- **Sources Consulted**: [Available voices - Amazon Polly](https://docs.aws.amazon.com/polly/latest/dg/available-voices.html), [Neural voices - Amazon Polly](https://docs.aws.amazon.com/polly/latest/dg/neural-voices.html)
+- **Findings**:
+  - Voice ID: `Kazuha`, Language: `ja-JP`, Gender: Female
+  - エンジン: Neural（Standard も対応）
+  - 出力形式: MP3, OGG, Raw PCM
+  - サンプルレート: MP3/OGG: 8/16/22/24kHz、**PCM: 8/16kHz のみ**（ニューラルデフォルト: 24kHz はPCMでは不可）
+  - SSML prosodyタグ対応（rate, pitch, volume）
+- **Implications**: PCM 16kHz出力を使用。LipSyncクラスの`playFromArrayBuffer(buffer, onEnded, false, 16000)`でsampleRate指定。デコード不要パス使用可能
+
+### 既存LipSyncクラスの互換性
+- **Context**: 無効化されたLipSyncが現行の音声パイプラインに適合するか確認
+- **Sources Consulted**: `src/features/lipSync/lipSync.ts` コード解析
+- **Findings**:
+  - PCM16パス: `isNeedDecode: false` でInt16Array→Float32Array変換、任意サンプルレート対応
+  - AudioContext制約対応: `setupUserInteractionDetection()` でclick/touchstart/keydown/mousedownを検出
+  - `pendingPlaybacks`キュー: AudioContext未開始時の再生リクエストを保留し、インタラクション後に再生
+  - `stopCurrentPlayback()`: 再生中の音声を即座に停止
+  - `update()`: 時間ドメインデータからボリューム計算（シグモイド関数で正規化）
+- **Implications**: 変更なしでそのまま利用可能。model.tsでインスタンスを作成しupdate()を呼ぶだけ
+
+### SpeakQueueの動作フロー
+- **Context**: SpeakQueueがmodel.speak()にどう接続するか確認
+- **Sources Consulted**: `src/features/messages/speakQueue.ts` コード解析
+- **Findings**:
+  - Singleton: `SpeakQueue.getInstance()`
+  - タスク追加: `addTask({ sessionId, audioBuffer, talk, isNeedDecode, onComplete })`
+  - processQueue: `await hs.viewer.model?.speak(audioBuffer, talk, isNeedDecode)` を呼び出し
+  - セッション管理: `checkSessionId()` で新セッション開始時にキューリセット
+  - stopAll: `model.stopSpeaking()` + キュークリア + stopTokenインクリメント
+- **Implications**: model.speak()がPromiseを返すように修正すれば、SpeakQueueは変更なしで動作
+
+### speakCharacterの呼び出しパターン
+- **Context**: speakCharacterがどこから呼ばれるか、分岐ロジックの影響範囲を確認
+- **Sources Consulted**: `src/features/chat/handlers.ts` コード解析
+- **Findings**:
+  - `handleSpeakAndStateUpdate()` から呼び出し: `speakCharacter(sessionId, {message, emotion}, onStart, onComplete)`
+  - `handleReceiveTextFromWsFn()` からも同シグネチャで呼び出し
+  - onStart: `hs.incrementChatProcessingCount()` — 処理中カウント増加
+  - onComplete: `hs.decrementChatProcessingCount()` — 処理中カウント減少
+- **Implications**: speakCharacter内部で分岐するだけで、呼び出し元(handlers.ts)の変更は不要
+
+## Design Decisions
+
+### Decision: PCM16直接再生 vs AudioBuffer経由
+- **Context**: Pollyの出力形式とLipSyncの入力形式の整合
+- **Alternatives Considered**:
+  1. PCM16バイナリをそのままLipSyncに渡す（isNeedDecode: false）
+  2. Polly出力をMP3にしてdecodeAudioData経由で渡す
+- **Selected Approach**: PCM16直接再生
+- **Rationale**: LipSyncクラスにPCM16パスが既に実装済み。デコード処理不要でレイテンシが小さい。PCM出力は16kHz上限だが音声品質は十分
+- **Trade-offs**: PCM16はMP3より転送サイズが大きい（約3倍）が、1文あたり数十KB程度で問題なし。16kHzは電話品質以上で会話用途には十分
+
+### Decision: LipSync遅延初期化
+- **Context**: LipSyncにはAudioContextが必要だが、音声OFF時は不要
+- **Alternatives Considered**:
+  1. Model初期化時にLipSyncを常に作成
+  2. 音声ON時に初めてLipSyncを作成（遅延初期化）
+- **Selected Approach**: 遅延初期化
+- **Rationale**: AudioContextはブラウザのリソースを消費する。音声OFFユーザーに不要なリソース確保を避ける
+- **Trade-offs**: 初回音声再生時に微小な初期化遅延（無視できるレベル）
+
+### Decision: speakCharacter内部分岐 vs 呼び出し元分岐
+- **Context**: 音声ON/OFFの分岐をどこに配置するか
+- **Alternatives Considered**:
+  1. handlers.tsで分岐し、speakCharacterとspeakWithAudioを使い分ける
+  2. speakCharacter内部でvoiceEnabled設定を参照して分岐する
+- **Selected Approach**: speakCharacter内部分岐
+- **Rationale**: handlers.tsの変更を最小限にし、既存の呼び出しパターンを維持。handlers.ts内の2箇所（handleSpeakAndStateUpdate, handleReceiveTextFromWsFn）を個別に修正する必要がなくなる
+- **Trade-offs**: speakCharacterの責務が若干増えるが、外部インターフェースが変わらない利点が上回る
+
+## Risks & Mitigations
+- **Polly APIレイテンシ**: 各文200-500ms + ネットワーク往復 → テキスト表示は即座に行い、音声は遅延して再生。SpeakQueueが順序を保証
+- **AudioContext制約**: リロード後にvoiceEnabledがONでも、ブラウザがAutoPlayをブロック → LipSyncのpendingPlaybacksキューが自動対応
+- **コスト**: ニューラル音声 $16/100万文字。個人利用レベルでは問題なし
+
+## References
+- [Amazon Polly Available Voices](https://docs.aws.amazon.com/polly/latest/dg/available-voices.html) — Kazuha音声の仕様確認
+- [Amazon Polly Neural Voices](https://docs.aws.amazon.com/polly/latest/dg/neural-voices.html) — ニューラル音声の出力形式・サンプルレート
+- [Optimizing Japanese TTS with Amazon Polly](https://aws.amazon.com/blogs/machine-learning/optimizing-japanese-text-to-speech-with-amazon-polly/) — 日本語TTS最適化ガイド

--- a/.kiro/specs/tts-polly-lipsync/spec.json
+++ b/.kiro/specs/tts-polly-lipsync/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "tts-polly-lipsync",
+  "created_at": "2026-02-23T00:00:00Z",
+  "updated_at": "2026-02-23T12:00:00Z",
+  "language": "ja",
+  "phase": "implementation-complete",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/tts-polly-lipsync/tasks.md
+++ b/.kiro/specs/tts-polly-lipsync/tasks.md
@@ -1,0 +1,73 @@
+# Implementation Plan
+
+## Task 1: TTS Lambdaとインフラ構築
+
+- [x] 1.1 TTS Lambda関数の作成
+  - テキストと感情を受け取り、感情に応じたSSML prosodyタグでテキストをラップしてPollyに送信する
+  - Amazon Polly SynthesizeSpeechでKazuhaニューラル音声を使い、PCM16 16kHzフォーマットで音声を合成する
+  - 6種の感情（happy, sad, angry, surprised, relaxed, neutral）に対応するSSML prosodyパラメータマッピングを実装する
+  - 未知の感情タグが渡された場合はneutralとして処理する
+  - ユーザー入力テキスト内のXML特殊文字（`<>&"'`）をエスケープしてSSMLインジェクションを防止する
+  - 空テキストや不正なリクエストボディに対してバリデーションエラーを返却する
+  - 音声バイナリをbase64エンコードしてJSON形式で応答する
+  - _Requirements: 1.1, 1.2, 1.3, 2.1, 2.2, 2.3_
+
+- [x] 1.2 CDKスタックにTTS LambdaとAPIルートを追加
+  - 既存のPythonFunction Lambdaパターンに倣い、TTS Lambda関数をCDKスタックに定義する
+  - LambdaのIAMロールにpolly:SynthesizeSpeechの実行権限を付与する
+  - 既存のAPI Gatewayに/ttsリソースとPOSTメソッドを追加する
+  - 既存のlambdaAuthorizerでエンドポイントを保護する
+  - _Requirements: 1.4_
+
+## Task 2: 音声設定の追加とUI
+
+- [x] 2.1 (P) voiceEnabled設定をストアに追加し永続化する
+  - 設定ストアにvoiceEnabled: boolean（デフォルトfalse）を追加する
+  - partializeに含めてブラウザのlocalStorageに永続化する
+  - _Requirements: 5.2, 5.3_
+
+- [x] 2.2 設定画面に音声ON/OFFトグルと翻訳キーを追加
+  - 既存のTextButtonトグルパターンに準拠したON/OFFボタンを設定画面に追加する
+  - 日本語（「音声出力」）と英語（"Voice Output"）の翻訳キーを追加する
+  - _Requirements: 5.1_
+
+## Task 3: Next.js TTS APIルートの作成
+
+- [x] 3. (P) Cognito M2M認証経由のTTSプロキシルートを作成
+  - テキストと感情を受け取り、Cognito M2Mトークンを取得してAPI Gatewayの/ttsエンドポイントにプロキシする
+  - Lambdaからのbase64エンコード応答をデコードし、PCM16バイナリとしてクライアントに返却する
+  - 空テキストや不正リクエストに対するバリデーションエラーを返却する
+  - Cognito認証失敗やAPI Gateway到達不可の場合に適切なエラーレスポンスを返却する
+  - _Requirements: 1.3, 1.4_
+
+## Task 4: ModelへのLipSync統合復元
+
+- [x] 4. (P) LipSyncの遅延初期化、音声再生・停止、音量連動リップシンクを復元
+  - 音声ON時に初めてLipSyncインスタンスを作成する遅延初期化メソッドを追加する
+  - 音声バッファを受け取りPCM16として再生し、再生完了までPromiseで待機するspeak()メソッドを復元する
+  - 再生中の音声を即座に停止するstopSpeaking()メソッドを復元する
+  - 毎フレームのupdate()ループでLipSyncの音量解析結果を取得し、音量に応じた口の開閉を駆動する
+  - 音量が小さい時は口をほぼ閉じ、大きい時は大きく開け、再生完了時は口を閉じた状態に戻す
+  - _Requirements: 3.1, 3.2, 3.3_
+
+## Task 5: speakCharacterの音声分岐とエラーハンドリング
+
+- [x] 5.1 voiceEnabled分岐と音声合成・キュー再生フローの実装
+  - 設定ストアからvoiceEnabledを参照し、ON/OFFで処理を分岐する
+  - ON時: TTS APIルートに音声合成をリクエストし、SpeakQueueにタスクを追加して順序付きキュー再生する
+  - OFF時: 既存のテキストベース母音リップシンクアニメーションをそのまま実行する
+  - onStart/onCompleteコールバックで発話中状態の管理を維持する
+  - 新しいセッション開始時やStop操作時にキューを適切にリセットする
+  - _Requirements: 4.1, 4.2, 4.3, 4.4, 5.4, 5.5_
+
+- [x] 5.2 エラーハンドリングとテキストリップシンクへのフォールバック
+  - 音声合成APIがエラーを返した場合にテキストベースリップシンクにフォールバックする
+  - ネットワーク不安定時にテキスト表示を維持しつつ音声再生のみスキップする
+  - AutoPlay制約はLipSyncクラスのpendingPlaybacksキューで自動対応する（既存実装を活用）
+  - _Requirements: 6.1, 6.2, 6.3_
+
+## Task 6: ビルド検証
+
+- [x] 6. 全コンポーネントの統合ビルド検証
+  - npm run buildでビルドが成功し、型エラーやLintエラーがないことを確認する
+  - 全要件のカバレッジを最終確認する

--- a/agentcore/src/agent/__init__.py
+++ b/agentcore/src/agent/__init__.py
@@ -1,4 +1,4 @@
-from .tonari_agent import create_tonari_agent
+from .tonari_agent import create_tonari_agent, create_tonari_agent_light
 from .prompts import TONARI_SYSTEM_PROMPT
 
-__all__ = ["create_tonari_agent", "TONARI_SYSTEM_PROMPT"]
+__all__ = ["create_tonari_agent", "create_tonari_agent_light", "TONARI_SYSTEM_PROMPT"]

--- a/infra/lambda/tts/index.py
+++ b/infra/lambda/tts/index.py
@@ -1,0 +1,102 @@
+"""
+TTS Lambda - Amazon Polly音声合成
+
+テキストと感情を受け取り、SSMLでPollyに音声合成をリクエストし、
+base64エンコードされたPCM16バイナリをJSON形式で返却する。
+"""
+import base64
+import json
+import logging
+from html import escape as html_escape
+
+import boto3
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+polly = boto3.client('polly')
+
+PROSODY_MAP = {
+    'happy':     {'rate': '105%', 'volume': 'medium'},
+    'angry':     {'rate': '110%', 'volume': 'loud'},
+    'sad':       {'rate': '85%',  'volume': 'soft'},
+    'surprised': {'rate': '115%', 'volume': 'medium'},
+    'relaxed':   {'rate': '90%',  'volume': 'soft'},
+    'neutral':   {},
+}
+
+
+def response(status_code: int, body: dict) -> dict:
+    """API Gateway形式のレスポンスを生成"""
+    return {
+        'statusCode': status_code,
+        'headers': {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+            'Access-Control-Allow-Methods': 'POST,OPTIONS',
+        },
+        'body': json.dumps(body, ensure_ascii=False),
+    }
+
+
+def escape_xml(text: str) -> str:
+    """XML特殊文字をエスケープする（SSMLインジェクション防止）"""
+    return html_escape(text, quote=True)
+
+
+def build_ssml(text: str, emotion: str) -> str:
+    """感情に応じたSSMLテキストを構築する"""
+    escaped_text = escape_xml(text)
+    params = PROSODY_MAP.get(emotion, {})
+
+    if params:
+        attrs = ' '.join(f'{k}="{v}"' for k, v in params.items())
+        return f'<speak><prosody {attrs}>{escaped_text}</prosody></speak>'
+
+    return f'<speak>{escaped_text}</speak>'
+
+
+def handler(event, context):
+    """Lambda handler"""
+    try:
+        body_str = event.get('body')
+        if not body_str:
+            return response(400, {'error': 'Request body is required'})
+
+        try:
+            body = json.loads(body_str)
+        except (json.JSONDecodeError, TypeError):
+            return response(400, {'error': 'Invalid JSON body'})
+
+        text = body.get('text', '')
+        if not text:
+            return response(400, {'error': 'Text is required'})
+
+        emotion = body.get('emotion', 'neutral')
+        voice = body.get('voice', 'Tomoko')
+        if voice not in ('Tomoko', 'Kazuha'):
+            voice = 'Tomoko'
+        ssml_text = build_ssml(text, emotion)
+
+        result = polly.synthesize_speech(
+            Engine='neural',
+            VoiceId=voice,
+            LanguageCode='ja-JP',
+            Text=ssml_text,
+            TextType='ssml',
+            OutputFormat='pcm',
+            SampleRate='16000',
+        )
+
+        audio_bytes = result['AudioStream'].read()
+        audio_b64 = base64.b64encode(audio_bytes).decode()
+
+        return response(200, {
+            'audio': audio_b64,
+            'sampleRate': 16000,
+        })
+
+    except Exception:
+        logger.exception('TTS synthesis failed')
+        return response(500, {'error': 'TTS synthesis failed'})

--- a/infra/lambda/tts/tests/test_index.py
+++ b/infra/lambda/tts/tests/test_index.py
@@ -1,0 +1,340 @@
+"""TTS Lambda unit tests"""
+import base64
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestHandler(unittest.TestCase):
+    """handler() integration tests"""
+
+    def _make_event(self, body: dict) -> dict:
+        return {
+            'httpMethod': 'POST',
+            'body': json.dumps(body),
+        }
+
+    @patch('index.polly')
+    def test_synthesize_success(self, mock_polly):
+        """Normal text synthesis returns base64 PCM16 audio"""
+        from index import handler
+
+        fake_audio = b'\x00\x01\x02\x03'
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = fake_audio
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = self._make_event({'text': 'こんにちは', 'emotion': 'neutral'})
+        result = handler(event, None)
+
+        self.assertEqual(result['statusCode'], 200)
+        body = json.loads(result['body'])
+        self.assertEqual(body['audio'], base64.b64encode(fake_audio).decode())
+        self.assertEqual(body['sampleRate'], 16000)
+
+        call_args = mock_polly.synthesize_speech.call_args
+        self.assertEqual(call_args.kwargs['Engine'], 'neural')
+        self.assertEqual(call_args.kwargs['VoiceId'], 'Tomoko')
+        self.assertEqual(call_args.kwargs['LanguageCode'], 'ja-JP')
+        self.assertEqual(call_args.kwargs['OutputFormat'], 'pcm')
+        self.assertEqual(call_args.kwargs['SampleRate'], '16000')
+
+    @patch('index.polly')
+    def test_synthesize_with_happy_emotion(self, mock_polly):
+        """Happy emotion applies correct SSML prosody"""
+        from index import handler
+
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = b'\x00'
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = self._make_event({'text': 'やった', 'emotion': 'happy'})
+        handler(event, None)
+
+        call_args = mock_polly.synthesize_speech.call_args
+        ssml_text = call_args.kwargs['Text']
+        self.assertIn('<speak>', ssml_text)
+        self.assertIn('rate="105%"', ssml_text)
+        self.assertNotIn('pitch=', ssml_text)
+        self.assertEqual(call_args.kwargs['TextType'], 'ssml')
+
+    @patch('index.polly')
+    def test_synthesize_with_angry_emotion(self, mock_polly):
+        """Angry emotion applies rate and volume"""
+        from index import handler
+
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = b'\x00'
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = self._make_event({'text': 'ふざけないで', 'emotion': 'angry'})
+        handler(event, None)
+
+        ssml_text = mock_polly.synthesize_speech.call_args.kwargs['Text']
+        self.assertIn('rate="110%"', ssml_text)
+        self.assertNotIn('pitch=', ssml_text)
+        self.assertIn('volume="loud"', ssml_text)
+
+    @patch('index.polly')
+    def test_synthesize_with_sad_emotion(self, mock_polly):
+        """Sad emotion applies slow rate and soft volume"""
+        from index import handler
+
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = b'\x00'
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = self._make_event({'text': '悲しい', 'emotion': 'sad'})
+        handler(event, None)
+
+        ssml_text = mock_polly.synthesize_speech.call_args.kwargs['Text']
+        self.assertIn('rate="85%"', ssml_text)
+        self.assertNotIn('pitch=', ssml_text)
+        self.assertIn('volume="soft"', ssml_text)
+
+    @patch('index.polly')
+    def test_synthesize_with_surprised_emotion(self, mock_polly):
+        """Surprised emotion applies fast rate"""
+        from index import handler
+
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = b'\x00'
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = self._make_event({'text': 'えっ', 'emotion': 'surprised'})
+        handler(event, None)
+
+        ssml_text = mock_polly.synthesize_speech.call_args.kwargs['Text']
+        self.assertIn('rate="115%"', ssml_text)
+        self.assertNotIn('pitch=', ssml_text)
+
+    @patch('index.polly')
+    def test_synthesize_with_relaxed_emotion(self, mock_polly):
+        """Relaxed emotion applies slow rate and soft volume"""
+        from index import handler
+
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = b'\x00'
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = self._make_event({'text': 'のんびり', 'emotion': 'relaxed'})
+        handler(event, None)
+
+        ssml_text = mock_polly.synthesize_speech.call_args.kwargs['Text']
+        self.assertIn('rate="90%"', ssml_text)
+        self.assertNotIn('pitch=', ssml_text)
+        self.assertIn('volume="soft"', ssml_text)
+
+    @patch('index.polly')
+    def test_neutral_emotion_no_prosody(self, mock_polly):
+        """Neutral emotion uses plain SSML without prosody tag"""
+        from index import handler
+
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = b'\x00'
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = self._make_event({'text': 'はい', 'emotion': 'neutral'})
+        handler(event, None)
+
+        ssml_text = mock_polly.synthesize_speech.call_args.kwargs['Text']
+        self.assertIn('<speak>', ssml_text)
+        self.assertNotIn('<prosody', ssml_text)
+
+    @patch('index.polly')
+    def test_unknown_emotion_falls_back_to_neutral(self, mock_polly):
+        """Unknown emotion is treated as neutral"""
+        from index import handler
+
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = b'\x00'
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = self._make_event({'text': 'テスト', 'emotion': 'unknown_emotion'})
+        handler(event, None)
+
+        ssml_text = mock_polly.synthesize_speech.call_args.kwargs['Text']
+        self.assertNotIn('<prosody', ssml_text)
+
+    @patch('index.polly')
+    def test_voice_kazuha(self, mock_polly):
+        """Kazuha voice is used when specified"""
+        from index import handler
+
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = b'\x00'
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = self._make_event({'text': 'テスト', 'voice': 'Kazuha'})
+        handler(event, None)
+
+        self.assertEqual(
+            mock_polly.synthesize_speech.call_args.kwargs['VoiceId'], 'Kazuha'
+        )
+
+    @patch('index.polly')
+    def test_invalid_voice_defaults_to_tomoko(self, mock_polly):
+        """Invalid voice falls back to Tomoko"""
+        from index import handler
+
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = b'\x00'
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = self._make_event({'text': 'テスト', 'voice': 'InvalidVoice'})
+        handler(event, None)
+
+        self.assertEqual(
+            mock_polly.synthesize_speech.call_args.kwargs['VoiceId'], 'Tomoko'
+        )
+
+
+class TestValidation(unittest.TestCase):
+    """Input validation tests"""
+
+    def _make_event(self, body) -> dict:
+        return {
+            'httpMethod': 'POST',
+            'body': json.dumps(body) if isinstance(body, dict) else body,
+        }
+
+    def test_empty_text_returns_400(self):
+        """Empty text string returns 400 error"""
+        from index import handler
+
+        event = self._make_event({'text': '', 'emotion': 'neutral'})
+        result = handler(event, None)
+
+        self.assertEqual(result['statusCode'], 400)
+        body = json.loads(result['body'])
+        self.assertIn('error', body)
+
+    def test_missing_text_returns_400(self):
+        """Missing text field returns 400 error"""
+        from index import handler
+
+        event = self._make_event({'emotion': 'neutral'})
+        result = handler(event, None)
+
+        self.assertEqual(result['statusCode'], 400)
+
+    def test_missing_body_returns_400(self):
+        """Null body returns 400 error"""
+        from index import handler
+
+        event = {'httpMethod': 'POST', 'body': None}
+        result = handler(event, None)
+
+        self.assertEqual(result['statusCode'], 400)
+
+    def test_invalid_json_body_returns_400(self):
+        """Non-JSON body returns 400 error"""
+        from index import handler
+
+        event = {'httpMethod': 'POST', 'body': 'not json'}
+        result = handler(event, None)
+
+        self.assertEqual(result['statusCode'], 400)
+
+    def test_missing_emotion_defaults_to_neutral(self):
+        """Missing emotion field defaults to neutral"""
+        from index import handler
+
+        with patch('index.polly') as mock_polly:
+            mock_stream = MagicMock()
+            mock_stream.read.return_value = b'\x00'
+            mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+            event = self._make_event({'text': 'テスト'})
+            result = handler(event, None)
+
+            self.assertEqual(result['statusCode'], 200)
+            ssml_text = mock_polly.synthesize_speech.call_args.kwargs['Text']
+            self.assertNotIn('<prosody', ssml_text)
+
+
+class TestXmlEscaping(unittest.TestCase):
+    """XML special character escaping tests"""
+
+    @patch('index.polly')
+    def test_escape_ampersand(self, mock_polly):
+        """Ampersand in text is escaped"""
+        from index import handler
+
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = b'\x00'
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = {
+            'httpMethod': 'POST',
+            'body': json.dumps({'text': 'A & B', 'emotion': 'neutral'}),
+        }
+        handler(event, None)
+
+        ssml_text = mock_polly.synthesize_speech.call_args.kwargs['Text']
+        self.assertIn('A &amp; B', ssml_text)
+        self.assertNotIn('A & B', ssml_text)
+
+    @patch('index.polly')
+    def test_escape_angle_brackets(self, mock_polly):
+        """Angle brackets in text are escaped"""
+        from index import handler
+
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = b'\x00'
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = {
+            'httpMethod': 'POST',
+            'body': json.dumps({'text': '<script>alert(1)</script>', 'emotion': 'neutral'}),
+        }
+        handler(event, None)
+
+        ssml_text = mock_polly.synthesize_speech.call_args.kwargs['Text']
+        self.assertNotIn('<script>', ssml_text)
+        self.assertIn('&lt;script&gt;', ssml_text)
+
+    @patch('index.polly')
+    def test_escape_quotes(self, mock_polly):
+        """Quotes in text are escaped"""
+        from index import handler
+
+        mock_stream = MagicMock()
+        mock_stream.read.return_value = b'\x00'
+        mock_polly.synthesize_speech.return_value = {'AudioStream': mock_stream}
+
+        event = {
+            'httpMethod': 'POST',
+            'body': json.dumps({'text': 'He said "hello" & \'bye\'', 'emotion': 'neutral'}),
+        }
+        handler(event, None)
+
+        ssml_text = mock_polly.synthesize_speech.call_args.kwargs['Text']
+        self.assertIn('&quot;', ssml_text)
+        # html.escape converts ' to &#x27; (valid XML numeric character reference)
+        self.assertIn('&#x27;', ssml_text)
+
+
+class TestPollyError(unittest.TestCase):
+    """Polly API error handling tests"""
+
+    @patch('index.polly')
+    def test_polly_error_returns_500(self, mock_polly):
+        """Polly API failure returns 500"""
+        from index import handler
+
+        mock_polly.synthesize_speech.side_effect = Exception('Polly error')
+
+        event = {
+            'httpMethod': 'POST',
+            'body': json.dumps({'text': 'テスト', 'emotion': 'neutral'}),
+        }
+        result = handler(event, None)
+
+        self.assertEqual(result['statusCode'], 500)
+        body = json.loads(result['body'])
+        self.assertIn('error', body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -236,5 +236,8 @@
   "AutoCaptureComplete": "Auto captured",
   "AutoCapture": "Auto capture",
   "AutoCaptureEnabled": "Auto capture ON",
-  "AutoCaptureDisabled": "Auto capture OFF"
+  "AutoCaptureDisabled": "Auto capture OFF",
+  "VoiceOutput": "Voice Output",
+  "VoiceOutputDescription": "Read AI responses aloud",
+  "VoiceModel": "Voice Model"
 }

--- a/locales/ja/translation.json
+++ b/locales/ja/translation.json
@@ -236,5 +236,8 @@
   "AutoCaptureComplete": "自動撮影しました",
   "AutoCapture": "自動撮影",
   "AutoCaptureEnabled": "自動撮影ON",
-  "AutoCaptureDisabled": "自動撮影OFF"
+  "AutoCaptureDisabled": "自動撮影OFF",
+  "VoiceOutput": "音声出力",
+  "VoiceOutputDescription": "AIの応答を音声で読み上げます",
+  "VoiceModel": "音声モデル"
 }

--- a/src/components/settings/based.tsx
+++ b/src/components/settings/based.tsx
@@ -15,6 +15,8 @@ const Based = () => {
   const showAssistantText = settingsStore((s) => s.showAssistantText)
   const showCharacterName = settingsStore((s) => s.showCharacterName)
   const showControlPanel = settingsStore((s) => s.showControlPanel)
+  const voiceEnabled = settingsStore((s) => s.voiceEnabled)
+  const voiceModel = settingsStore((s) => s.voiceModel)
   const useVideoAsBackground = settingsStore((s) => s.useVideoAsBackground)
   const changeEnglishToJapanese = settingsStore(
     (s) => s.changeEnglishToJapanese
@@ -239,6 +241,42 @@ const Based = () => {
             {showControlPanel ? t('StatusOn') : t('StatusOff')}
           </TextButton>
         </div>
+      </div>
+
+      {/* 音声出力設定 */}
+      <div className="my-6">
+        <div className="my-4 text-xl font-bold">{t('VoiceOutput')}</div>
+        <div className="my-4 whitespace-pre-wrap">
+          {t('VoiceOutputDescription')}
+        </div>
+        <div className="my-2">
+          <TextButton
+            onClick={() =>
+              settingsStore.setState((s) => ({
+                voiceEnabled: !s.voiceEnabled,
+              }))
+            }
+          >
+            {voiceEnabled ? t('StatusOn') : t('StatusOff')}
+          </TextButton>
+        </div>
+        {voiceEnabled && (
+          <div className="my-4">
+            <div className="my-2 font-bold">{t('VoiceModel')}</div>
+            <div className="my-2 flex gap-2">
+              <TextButton
+                onClick={() => settingsStore.setState({ voiceModel: 'Tomoko' })}
+              >
+                Tomoko{voiceModel === 'Tomoko' ? ' ✓' : ''}
+              </TextButton>
+              <TextButton
+                onClick={() => settingsStore.setState({ voiceModel: 'Kazuha' })}
+              >
+                Kazuha{voiceModel === 'Kazuha' ? ' ✓' : ''}
+              </TextButton>
+            </div>
+          </div>
+        )}
       </div>
     </>
   )

--- a/src/features/messages/speakQueue.ts
+++ b/src/features/messages/speakQueue.ts
@@ -3,7 +3,7 @@ import homeStore from '@/features/stores/home'
 
 type SpeakTask = {
   sessionId: string
-  audioBuffer: ArrayBuffer
+  audioBuffer: ArrayBuffer | Promise<ArrayBuffer>
   talk: Talk
   isNeedDecode: boolean
   onComplete?: () => void
@@ -105,7 +105,8 @@ export class SpeakQueue {
           continue
         }
         try {
-          const { audioBuffer, talk, isNeedDecode, onComplete } = task
+          const audioBuffer = await Promise.resolve(task.audioBuffer)
+          const { talk, isNeedDecode, onComplete } = task
           await hs.viewer.model?.speak(audioBuffer, talk, isNeedDecode)
           onComplete?.()
         } catch (error) {
@@ -116,6 +117,8 @@ export class SpeakQueue {
           if (error instanceof Error) {
             console.error('Error details:', error.message)
           }
+          // TTS取得や再生に失敗してもonCompleteを呼んでカウントを正しく減算
+          task.onComplete?.()
         }
       }
     }

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -84,6 +84,8 @@ interface General {
   colorTheme: 'tonari'
   customModel: boolean
   enableAutoCapture: boolean
+  voiceEnabled: boolean
+  voiceModel: 'Tomoko' | 'Kazuha'
 }
 
 export type SettingsState = APIKeys & ModelProvider & Character & General
@@ -168,6 +170,8 @@ const getInitialValuesFromEnv = (): SettingsState => {
     colorTheme: 'tonari' as const,
     customModel: config.ai.customModel,
     enableAutoCapture: true,
+    voiceEnabled: false,
+    voiceModel: 'Tomoko',
   }
 }
 
@@ -265,6 +269,8 @@ const settingsStore = create<SettingsState>()(
       colorTheme: state.colorTheme,
       customModel: state.customModel,
       enableAutoCapture: state.enableAutoCapture,
+      voiceEnabled: state.voiceEnabled,
+      voiceModel: state.voiceModel,
     }),
   })
 )

--- a/src/features/vrmViewer/model.ts
+++ b/src/features/vrmViewer/model.ts
@@ -10,6 +10,7 @@ import { VRMAnimation } from '../../lib/VRMAnimation/VRMAnimation'
 import { VRMLookAtSmootherLoaderPlugin } from '@/lib/VRMLookAtSmootherLoaderPlugin/VRMLookAtSmootherLoaderPlugin'
 import { EmoteController } from '../emoteController/emoteController'
 import { Talk } from '../messages/messages'
+import { LipSync } from '../lipSync/lipSync'
 
 /**
  * 3Dキャラクターを管理するクラス
@@ -20,10 +21,10 @@ export class Model {
   public emoteController?: EmoteController
 
   private _lookAtTargetParent: THREE.Object3D
+  private _lipSync?: LipSync
 
   constructor(lookAtTargetParent: THREE.Object3D) {
     this._lookAtTargetParent = lookAtTargetParent
-    // Tonariでは音声出力機能を削除しているため、LipSyncは作成しない
   }
 
   public async loadVRM(url: string): Promise<void> {
@@ -70,23 +71,48 @@ export class Model {
   }
 
   /**
+   * LipSyncインスタンスを遅延初期化する
+   */
+  public initLipSync(): void {
+    if (this._lipSync) return
+    const audioContext = new AudioContext()
+    this._lipSync = new LipSync(audioContext)
+  }
+
+  /**
    * 音声を再生し、リップシンクを行う
-   * Tonariでは音声出力機能を削除しているため、表情のみ設定
    */
   public async speak(
     buffer: ArrayBuffer,
     talk: Talk,
     isNeedDecode: boolean = true
-  ) {
+  ): Promise<void> {
     this.emoteController?.playEmotion(talk.emotion)
-    // 音声再生なしのため即座に完了
+
+    if (!this._lipSync) {
+      return
+    }
+
+    return new Promise((resolve) => {
+      this._lipSync!.playFromArrayBuffer(
+        buffer,
+        () => {
+          // 再生完了時に口を閉じる
+          this.emoteController?.lipSync('aa', 0)
+          resolve()
+        },
+        isNeedDecode,
+        16000
+      )
+    })
   }
 
   /**
    * 現在の音声再生を停止
    */
   public stopSpeaking() {
-    // Tonariでは音声出力機能を削除しているため、何もしない
+    this._lipSync?.stopCurrentPlayback()
+    this.emoteController?.lipSync('aa', 0)
   }
 
   /**
@@ -104,7 +130,11 @@ export class Model {
   }
 
   public update(delta: number): void {
-    // Tonariでは音声出力機能を削除しているため、リップシンク処理はスキップ
+    // 音声リップシンク：音量に応じて口の開閉を駆動
+    if (this._lipSync) {
+      const { volume } = this._lipSync.update()
+      this.emoteController?.lipSync('aa', volume)
+    }
 
     // 表情・瞬きの更新（ジェスチャー以外）
     this.emoteController?.updateExpression(delta)

--- a/src/pages/api/tts.ts
+++ b/src/pages/api/tts.ts
@@ -1,0 +1,57 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getCognitoToken } from '@/lib/cognito'
+
+const API_BASE_URL = process.env.PERFUME_API_URL || ''
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { text, emotion, voice } = req.body || {}
+
+  if (!text || typeof text !== 'string') {
+    return res.status(400).json({ error: 'Text is required' })
+  }
+
+  if (!API_BASE_URL) {
+    console.error('PERFUME_API_URL is not configured')
+    return res.status(500).json({ error: 'TTS service not configured' })
+  }
+
+  try {
+    const token = await getCognitoToken()
+
+    const response = await fetch(`${API_BASE_URL}/tts`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        text,
+        emotion: emotion || 'neutral',
+        voice: voice || 'Tomoko',
+      }),
+    })
+
+    if (!response.ok) {
+      const errorBody = await response.text()
+      console.error('TTS API error:', response.status, errorBody)
+      return res.status(response.status).json({ error: 'TTS synthesis failed' })
+    }
+
+    const data = await response.json()
+    const audioBuffer = Buffer.from(data.audio, 'base64')
+
+    res.setHeader('Content-Type', 'audio/pcm')
+    res.setHeader('Content-Length', audioBuffer.length)
+    return res.status(200).send(audioBuffer)
+  } catch (error) {
+    console.error('TTS route error:', error)
+    return res.status(500).json({ error: 'TTS service unavailable' })
+  }
+}


### PR DESCRIPTION
## Summary
- Amazon Polly (Neural) を使った音声読み上げ機能を追加し、無効化されていたLipSync/SpeakQueueを再有効化してVRMモデルのリップシンクと連動
- 感情タグに応じたSSML prosody変換 (happy/sad/angry/surprised/relaxed) で抑揚のある音声を実現
- 設定画面に音声ON/OFF + 音声モデル切替 (Tomoko/Kazuha) を追加
- AgentCore Runtime に軽量モード導入：雑談時はGateway接続・LTM検索をスキップし応答速度を改善

## 変更内容

### TTS基盤
- `infra/lambda/tts/index.py` — Polly TTS Lambda (PCM16, 16kHz)
- `infra/lib/tonari-stack.ts` — CDKインフラ (Lambda + API Gateway統合)
- `src/pages/api/tts.ts` — Next.js TTS プロキシルート

### 音声再生 & リップシンク
- `src/features/vrmViewer/model.ts` — LipSync再有効化、speak/stopSpeaking/update復元
- `src/features/messages/speakCharacter.ts` — voiceEnabled分岐 (音声パス/テキストパス)
- `src/features/messages/speakQueue.ts` — Promise\<ArrayBuffer\>対応で再生順序保証

### バグ修正
- `src/features/chat/handlers.ts` — ジェスチャータグ `[bow]`/`[present]` の音声混入を修正、感情タグ誤検出を修正

### 設定 & UI
- `src/features/stores/settings.ts` — voiceEnabled, voiceModel 追加
- `src/components/settings/based.tsx` — 音声ON/OFF + モデル切替UI
- `locales/ja/translation.json`, `locales/en/translation.json` — 翻訳キー追加

### AgentCore最適化
- `agentcore/app.py` — ツールキーワード判定で軽量/フルモード分岐
- `agentcore/src/agent/tonari_agent.py` — `create_tonari_agent_light()` (STMのみ、ツール/LTMなし)

## Test plan
- [x] TTS Lambda ユニットテスト 19件通過 (感情prosody, XMLエスケープ, 音声モデル切替, バリデーション)
- [ ] 設定画面で音声ON/OFFを切り替え、音声が再生/停止されること
- [ ] Tomoko/Kazuha切替が反映されること
- [ ] 雑談メッセージの応答速度が改善されていること
- [ ] 香水関連メッセージでツール使用が正常に動作すること
- [ ] 音声OFF時に既存のテキストベース口パクが正常動作すること

Closes #32