### PR TITLE
feat: Agentインスタンス使い回し＋お辞儀中の表情修正

### DIFF
--- a/src/features/emoteController/expressionController.ts
+++ b/src/features/emoteController/expressionController.ts
@@ -33,6 +33,9 @@ export class ExpressionController {
   }
 
   public playEmotion(preset: VRMExpressionPresetName) {
+    // Skip if the same emotion is already active (avoid flicker on re-set)
+    if (preset === this._currentEmotion) return
+
     if (this._currentEmotion != 'neutral') {
       this._expressionManager?.setValue(this._currentEmotion, 0)
     }

--- a/src/features/messages/speakCharacter.ts
+++ b/src/features/messages/speakCharacter.ts
@@ -251,6 +251,11 @@ const speakWithAudio = (
   onStart?.()
 
   const { viewer } = homeStore.getState()
+
+  // Set emotion immediately (before waiting for audio fetch)
+  // This ensures gesture skipEyeClose works from the first frame
+  viewer.model?.emoteController?.playEmotion(talk.emotion)
+
   viewer.model?.initLipSync()
 
   const { voiceModel } = settingsStore.getState()


### PR DESCRIPTION
## Summary
- AgentCore: 同一セッション中はAgentインスタンスを使い回し、毎リクエストの初期化コスト（BedrockModel・MCPClient・Gateway接続）を削減
- AgentCore: `needs_tools()`キーワードルーティングを廃止し、常にフル装備Agentを使用。ツール使用はLLMが自律判断
- フロント: 音声パス(`speakWithAudio`)で感情を即座に設定し、お辞儀ジェスチャー中の目閉じが表情(happy等)と競合する問題を修正
- フロント: `playEmotion()`で同じ感情の再設定時にフリッカー（値が0→1に一瞬リセットされる）を防止

## Test plan
- [ ] 1回目のメッセージ送信後、2回目以降のレスポンス速度が改善されていることを確認
- [ ] ツールが必要なメッセージ（香水検索等）でツールが正しく使用されることを確認
- [ ] お辞儀＋笑顔の組み合わせで目が閉じず、笑顔が維持されることを確認
- [ ] 音声ON/OFFの両方で感情表現が正しく動作することを確認