### PR TITLE
Improve mobile UI layout and navigation

### DIFF
--- a/src/components/mobileHeader.tsx
+++ b/src/components/mobileHeader.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import Link from 'next/link'
 import Image from 'next/image'
 import { IconButton } from './iconButton'
 import Settings from './settings'
@@ -30,32 +31,45 @@ export const MobileHeader = () => {
   return (
     <>
       <header
-        className="flex-shrink-0 px-4 py-2 flex items-center justify-between"
+        className="absolute top-0 left-0 right-0 z-20 px-4 py-2 flex items-center justify-end"
         role="banner"
       >
-        <Image src="/logo.png" alt="TONaRi" width={120} height={40} priority />
-        {showControlPanel && (
-          <nav className="flex gap-2" aria-label="Main navigation">
-            <IconButton
-              iconName="24/Refresh"
-              isProcessing={false}
-              onClick={handleNewSession}
-              aria-label="新しいセッション"
-            />
-            <IconButton
-              iconName="24/Swap"
-              isProcessing={false}
-              onClick={handleSwitchVrmModel}
-              aria-label="モデル切り替え"
-            />
-            <IconButton
-              iconName="24/Settings"
-              isProcessing={false}
-              onClick={() => setShowSettings(true)}
-              aria-label={t('BasedSettings')}
-            />
-          </nav>
-        )}
+        <nav className="flex gap-2" aria-label="Main navigation">
+          {showControlPanel && (
+            <>
+              <IconButton
+                iconName="24/Refresh"
+                isProcessing={false}
+                onClick={handleNewSession}
+                aria-label="新しいセッション"
+              />
+              <IconButton
+                iconName="24/Swap"
+                isProcessing={false}
+                onClick={handleSwitchVrmModel}
+                aria-label="モデル切り替え"
+              />
+              <Link
+                href="/admin/perfumes"
+                className="bg-primary hover:bg-primary-hover active:bg-primary-press rounded-2xl text-sm p-2 text-center inline-flex items-center transition-all duration-200 text-theme"
+                aria-label={t('PerfumeDataManagement')}
+              >
+                <Image
+                  src="/images/icons/database.svg"
+                  alt={t('PerfumeDataManagement')}
+                  width={24}
+                  height={24}
+                />
+              </Link>
+            </>
+          )}
+          <IconButton
+            iconName="24/Settings"
+            isProcessing={false}
+            onClick={() => setShowSettings(true)}
+            aria-label={t('BasedSettings')}
+          />
+        </nav>
       </header>
       {showSettings && <Settings onClickClose={() => setShowSettings(false)} />}
     </>

--- a/src/components/vrmViewer.tsx
+++ b/src/components/vrmViewer.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef } from 'react'
 
 import homeStore from '@/features/stores/home'
 import settingsStore from '@/features/stores/settings'
-import { GestureTestPanel } from './gestureTestPanel'
 
 export default function VrmViewer() {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -71,7 +70,6 @@ export default function VrmViewer() {
       className={'relative w-full h-full overflow-hidden'}
     >
       <canvas ref={canvasRef} className={'h-full w-full'}></canvas>
-      {/* <GestureTestPanel /> */}
     </div>
   )
 }

--- a/src/components/vrmViewer.tsx
+++ b/src/components/vrmViewer.tsx
@@ -71,7 +71,7 @@ export default function VrmViewer() {
       className={'relative w-full h-full overflow-hidden'}
     >
       <canvas ref={canvasRef} className={'h-full w-full'}></canvas>
-      {process.env.NODE_ENV === 'development' && <GestureTestPanel />}
+      {/* <GestureTestPanel /> */}
     </div>
   )
 }

--- a/src/features/vrmViewer/viewer.ts
+++ b/src/features/vrmViewer/viewer.ts
@@ -189,11 +189,10 @@ export class Viewer {
       // モバイル判定（画面幅768px以下）
       const isMobile = window.innerWidth <= 768
 
-      // モバイル時はカメラを近づけて頭部をアップで表示
-      const cameraZ = isMobile ? 0.8 : (this._camera?.position.z ?? 1.5)
-      // モバイル時はカメラを少し下に、ターゲットを少し上にして頭頂部を表示
-      const cameraYOffset = isMobile ? 0.1 : 0
-      const targetYOffset = isMobile ? 0.05 : 0
+      // モバイル時はカメラを引きで表示（上半身が見える程度）
+      const cameraZ = isMobile ? 1.5 : (this._camera?.position.z ?? 1.5)
+      const cameraYOffset = 0
+      const targetYOffset = 0
 
       this._camera?.position.set(
         this._camera.position.x,

--- a/src/features/vrmViewer/viewer.ts
+++ b/src/features/vrmViewer/viewer.ts
@@ -186,24 +186,12 @@ export class Viewer {
     if (headNode) {
       const headWPos = headNode.getWorldPosition(new THREE.Vector3())
 
-      // モバイル判定（画面幅768px以下）
-      const isMobile = window.innerWidth <= 768
-
-      // モバイル時はカメラを引きで表示（上半身が見える程度）
-      const cameraZ = isMobile ? 1.5 : (this._camera?.position.z ?? 1.5)
-      const cameraYOffset = 0
-      const targetYOffset = 0
-
       this._camera?.position.set(
         this._camera.position.x,
-        headWPos.y + cameraYOffset,
-        cameraZ
+        headWPos.y,
+        this._camera?.position.z ?? 1.5
       )
-      this._cameraControls?.target.set(
-        headWPos.x,
-        headWPos.y + targetYOffset,
-        headWPos.z
-      )
+      this._cameraControls?.target.set(headWPos.x, headWPos.y, headWPos.z)
       this._cameraControls?.update()
     }
   }

--- a/src/pages/admin/login.tsx
+++ b/src/pages/admin/login.tsx
@@ -72,7 +72,7 @@ export default function AdminLogin() {
           setShowRegisterPrompt(true)
           setShowPasswordForm(false)
         } else {
-          window.location.href = '/admin/perfumes'
+          window.location.href = '/admin/perfumes/'
         }
       } else {
         setError('認証失敗')
@@ -113,7 +113,7 @@ export default function AdminLogin() {
           CREDENTIAL_STORAGE_KEY,
           JSON.stringify(verifyData.credential)
         )
-        window.location.href = '/admin/perfumes'
+        window.location.href = '/admin/perfumes/'
       }
     } catch {
       setError('登録失敗')
@@ -159,7 +159,7 @@ export default function AdminLogin() {
       if (verifyData.verified) {
         credential.counter = verifyData.newCounter
         localStorage.setItem(CREDENTIAL_STORAGE_KEY, JSON.stringify(credential))
-        window.location.href = '/admin/perfumes'
+        window.location.href = '/admin/perfumes/'
       }
     } catch {
       setError('認証失敗')

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -83,10 +83,10 @@ const Home = () => {
       <Meta />
       {isMobile ? (
         <>
-          {/* モバイル: ヘッダー（最上部） */}
+          {/* モバイル: ヘッダー（VRMビューワー上に透過で重ねる） */}
           <MobileHeader />
           {/* モバイル: VRMビューワー */}
-          <div className="h-[35vh] min-h-[180px]">
+          <div className="relative h-[50vh] min-h-[250px]">
             <VrmViewer />
           </div>
           {/* モバイル: チャットUI（中央） */}


### PR DESCRIPTION
## 概要
モバイル表示時のUI/UXを改善し、VRMモデルの表示領域を拡大、ヘッダーを透過表示に変更。

## 変更点
- ヘッダーを透過表示に変更し、VRMビューワー上に重ねて表示
- ロゴ表示を削除し、ナビゲーションを右寄せに配置
- 設定ボタンをコントロールパネルの表示状態に関わらず常時表示
- 管理画面（香水データ管理）への遷移ボタンをモバイルヘッダーに追加
- VRMビューワーの表示領域を35vh→50vhに拡大
- モバイル時のカメラ距離を調整し、上半身が見える引きの表示に変更
- GestureTestPanelを非表示に変更
- `login.tsx`のナビゲーションURLにtrailing slashを追加し、開発環境でのNext.jsルーターエラーを解消