### PR TITLE
Fix passkey registration prompt not showing on iPhone Chrome

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -91,21 +91,9 @@ export default function Login() {
       })
 
       if (res.ok) {
-        // Re-check WebAuthn availability at submission time
-        // (mount-time check may have failed due to timing or secure context)
-        let canRegister = false
-        try {
-          if (browserSupportsWebAuthn()) {
-            const available =
-              await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
-            canRegister =
-              available && !localStorage.getItem(CREDENTIAL_STORAGE_KEY)
-          }
-        } catch {
-          // WebAuthn not available
-        }
-
-        if (canRegister) {
+        // Show passkey registration prompt if not yet registered
+        // (even if WebAuthn is unavailable — user can SKIP if registration fails)
+        if (!localStorage.getItem(CREDENTIAL_STORAGE_KEY)) {
           setIsTouchIdAvailable(true)
           setShowRegisterPrompt(true)
           setShowPasswordForm(false)


### PR DESCRIPTION
## 概要
iPhone (Chrome) でパスワードログイン後にパスキー登録画面が表示されない問題を修正。

## 変更点
- パスキー登録画面の表示条件から `browserSupportsWebAuthn()` と `isUserVerifyingPlatformAuthenticatorAvailable()` のチェックを除外
- `localStorage` に未登録なら常に登録画面を表示するように簡素化
- WebAuthn非対応ブラウザでは登録が失敗するが、SKIPボタンでTopに遷移可能

## 背景
iOS上のChromeはWebKitエンジンを使用するが、`PublicKeyCredential` の公開状況がSafariと異なる場合があり、`browserSupportsWebAuthn()` が `false` を返すケースがあった。