### PR TITLE
Fix passkey login screen not showing after logout on iPhone

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -52,28 +52,13 @@ export default function Login() {
     setHasError(true)
   }, [])
 
-  const checkTouchIdAvailability = async () => {
-    if (!browserSupportsWebAuthn()) {
-      setShowPasswordForm(true)
-      return
-    }
-
-    try {
-      const available =
-        await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
-      setIsTouchIdAvailable(available)
-
-      if (available) {
-        const stored = localStorage.getItem(CREDENTIAL_STORAGE_KEY)
-        if (stored) {
-          setHasRegisteredCredential(true)
-        } else {
-          setShowPasswordForm(true)
-        }
-      } else {
-        setShowPasswordForm(true)
-      }
-    } catch {
+  const checkTouchIdAvailability = () => {
+    const stored = localStorage.getItem(CREDENTIAL_STORAGE_KEY)
+    if (stored) {
+      // Credential exists = passkey was registered before, show Touch ID
+      setIsTouchIdAvailable(true)
+      setHasRegisteredCredential(true)
+    } else {
       setShowPasswordForm(true)
     }
   }


### PR DESCRIPTION
## 概要
ログアウト後にパスキーログイン画面（Touch IDボタン）が表示されず、パスワードフォームになる問題を修正。

## 変更点
- `checkTouchIdAvailability` のマウント時チェックを `localStorage` のみに簡素化
- `browserSupportsWebAuthn()` / `isUserVerifyingPlatformAuthenticatorAvailable()` の判定を除外
- credentialが `localStorage` に存在すれば Touch IDボタンを表示（過去に登録成功済みのため安全）

## 背景
PR #49 でパスキー登録画面の表示を修正したが、ログアウト後の再表示時にも同じ `browserSupportsWebAuthn()` チェックが残っておりiPhone Chromeで失敗していた。