### PR TITLE
feat: Stream tool usage status to chat UI

### DIFF
--- a/src/components/chatLog.tsx
+++ b/src/components/chatLog.tsx
@@ -13,6 +13,9 @@ export const ChatLog = () => {
   const messages = messageSelectors.getTextAndImageMessages(
     homeStore((s) => s.chatLog)
   )
+  const toolStatusMessage = homeStore((s) =>
+    s.chatLog.find((msg) => msg.role === 'tool-status')
+  )
 
   useEffect(() => {
     chatScrollRef.current?.scrollIntoView({
@@ -26,7 +29,7 @@ export const ChatLog = () => {
       behavior: 'smooth',
       block: 'center',
     })
-  }, [messages, chatProcessing])
+  }, [messages, chatProcessing, toolStatusMessage])
 
   return (
     <div className="h-full w-full overflow-y-auto px-4 py-4">
@@ -65,13 +68,26 @@ export const ChatLog = () => {
           </div>
         )
       })}
-      {chatProcessing &&
+      {chatProcessing && toolStatusMessage ? (
+        <div ref={chatScrollRef}>
+          <ToolStatusIndicator
+            characterName={characterName}
+            toolName={
+              typeof toolStatusMessage.content === 'string'
+                ? toolStatusMessage.content
+                : ''
+            }
+          />
+        </div>
+      ) : (
+        chatProcessing &&
         (messages.length === 0 ||
           messages[messages.length - 1].role === 'user') && (
           <div ref={chatScrollRef}>
             <LoadingIndicator characterName={characterName} />
           </div>
-        )}
+        )
+      )}
     </div>
   )
 }
@@ -96,6 +112,28 @@ const LoadingIndicator = ({ characterName }: { characterName: string }) => {
             className="w-2 h-2 bg-secondary rounded-full animate-bounce"
             style={{ animationDelay: '300ms' }}
           />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const ToolStatusIndicator = ({
+  characterName,
+  toolName,
+}: {
+  characterName: string
+  toolName: string
+}) => {
+  return (
+    <div className="mx-auto ml-0 md:ml-10 lg:ml-20 my-4 pr-10">
+      <div className="px-6 py-2 rounded-t-lg font-bold tracking-wider bg-secondary text-theme">
+        {characterName || 'CHARACTER'}
+      </div>
+      <div className="px-6 py-4 bg-white rounded-b-lg">
+        <div className="flex items-center gap-2 animate-pulse">
+          <span className="text-base">&#128295;</span>
+          <span className="text-secondary font-bold">{toolName}...</span>
         </div>
       </div>
     </div>

--- a/src/features/chat/aiChatFactory.ts
+++ b/src/features/chat/aiChatFactory.ts
@@ -1,8 +1,13 @@
-import { getAgentCoreChatResponseStream } from './agentCoreChat'
+import {
+  getAgentCoreChatResponseStream,
+  type StreamChunk,
+} from './agentCoreChat'
+
+export type { StreamChunk }
 
 export async function getAIChatResponseStream(
   userMessage: string,
   imageBase64?: string
-): Promise<ReadableStream<string> | null> {
+): Promise<ReadableStream<StreamChunk> | null> {
   return getAgentCoreChatResponseStream(userMessage, imageBase64)
 }

--- a/src/features/messages/messageSelectors.ts
+++ b/src/features/messages/messageSelectors.ts
@@ -2,10 +2,11 @@ import { Message } from './messages'
 import settingsStore from '@/features/stores/settings'
 
 export const messageSelectors = {
-  // テキストまたは画像を含むメッセージのみを取得
+  // テキストまたは画像を含むメッセージのみを取得（tool-statusは除外）
   getTextAndImageMessages: (messages: Message[]): Message[] => {
     return messages.filter((message): boolean => {
       if (!message.content) return false
+      if (message.role === 'tool-status') return false
       return (
         typeof message.content === 'string' || Array.isArray(message.content)
       )

--- a/src/features/stores/home.ts
+++ b/src/features/stores/home.ts
@@ -119,7 +119,9 @@ const homeStore = create<HomeState>()(
     {
       name: 'aitube-kit-home',
       partialize: ({ chatLog }) => ({
-        chatLog: messageSelectors.cutImageMessage(chatLog),
+        chatLog: messageSelectors.cutImageMessage(
+          chatLog.filter((msg) => msg.role !== 'tool-status')
+        ),
       }),
       onRehydrateStorage: () => (state) => {
         if (state) {
@@ -143,12 +145,13 @@ homeStore.subscribe((state, prevState) => {
     }
 
     saveDebounceTimer = setTimeout(() => {
-      // 新規追加 or 更新があったメッセージだけを抽出
+      // 新規追加 or 更新があったメッセージだけを抽出（tool-statusは除外）
       const newMessagesToSave = state.chatLog.filter(
         (msg, idx) =>
-          idx >= lastSavedLogLength || // 追加分
-          prevState.chatLog.find((p) => p.id === msg.id)?.content !==
-            msg.content // 更新分
+          msg.role !== 'tool-status' &&
+          (idx >= lastSavedLogLength || // 追加分
+            prevState.chatLog.find((p) => p.id === msg.id)?.content !==
+              msg.content) // 更新分
       )
 
       if (newMessagesToSave.length > 0) {


### PR DESCRIPTION
## 概要

エージェントがツール（香水検索、Web検索、ツイート投稿等）を使用中、ユーザーには何も表示されず長時間の「考え中...」状態が続いていた問題を改善。ツール使用状況をリアルタイムでストリーミング表示する。

## 変更点

### Backend (`agentcore/app.py`)
- `_stream_response` に Strands Agent の `current_tool_use` イベント検出を追加
- `tool_start` / `tool_end` イベントを構造化 dict として yield

### API Route (`agentcore.ts`)
- `parseJsonString` → `parseSSEData` に置換し、テキスト・ツールイベント両方をSSE転送

### Client Stream (`agentCoreChat.ts`, `aiChatFactory.ts`)
- `ToolEvent` / `StreamChunk` 型を定義
- `ReadableStream<string>` → `ReadableStream<StreamChunk>` に変更

### Chat Handler (`handlers.ts`)
- ツール名→日本語マッピング（6ツール対応: 香水検索、ツイート確認/投稿、日記保存/取得、Web検索）
- `processAIResponse` でツールイベントを処理し、tool-status メッセージを upsert/削除

### UI (`chatLog.tsx`)
- `ToolStatusIndicator` コンポーネントを追加（パルスアニメーション付き、例: 「🔧 香水を検索中...」）
- ツール使用中は LoadingIndicator の代わりに表示

### Persistence (`home.ts`, `messageSelectors.ts`)
- `tool-status` メッセージを localStorage 永続化・save-chat-log API・メッセージ表示から除外

## 確認項目

- [x] `npm run build` 成功
- [x] AgentCore デプロイ済み
- [x] ローカルで動作確認

Closes #53