### PR TITLE
feat: ダークモード実装

### DIFF
--- a/src/components/cameraPreview.tsx
+++ b/src/components/cameraPreview.tsx
@@ -92,8 +92,8 @@ export const CameraButton = () => {
       isProcessing={false}
       disabled={chatProcessing}
       onClick={() => homeStore.setState({ cameraOpen: true })}
-      className="bg-white/70 hover:bg-white hover:shadow-md border border-gray-400/60 disabled:opacity-50 disabled:cursor-not-allowed"
-      iconColor="text-gray-700"
+      className="bg-white/70 hover:bg-white hover:shadow-md border border-gray-400/60 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700/70 dark:hover:bg-gray-600 dark:border-gray-500/60"
+      iconColor="text-gray-700 dark:text-gray-300"
       aria-label={t('OpenCamera')}
     />
   )

--- a/src/components/chatLog.tsx
+++ b/src/components/chatLog.tsx
@@ -221,7 +221,7 @@ const LoadingIndicator = ({
       <div className="px-6 py-2 rounded-t-lg font-bold tracking-wider bg-secondary text-theme">
         {characterName || 'CHARACTER'}
       </div>
-      <div className="px-6 py-4 bg-white rounded-b-lg">
+      <div className="px-6 py-4 bg-white dark:bg-white/10 rounded-b-lg">
         <div className="flex items-center gap-1">
           <span
             className="w-2 h-2 bg-secondary rounded-full animate-bounce"
@@ -259,7 +259,7 @@ const ToolStatusIndicator = ({
       <div className="px-6 py-2 rounded-t-lg font-bold tracking-wider bg-secondary text-theme">
         {characterName || 'CHARACTER'}
       </div>
-      <div className="px-6 py-4 bg-white rounded-b-lg">
+      <div className="px-6 py-4 bg-white dark:bg-white/10 rounded-b-lg">
         <div className="flex items-center gap-2 animate-pulse">
           <span className="text-base">&#128295;</span>
           <span className="text-secondary font-bold">{toolName}...</span>
@@ -345,7 +345,7 @@ const Chat = ({
           >
             {role !== 'user' ? characterName || 'CHARACTER' : 'YOU'}
           </div>
-          <div className="px-6 py-4 bg-white rounded-b-lg">
+          <div className="px-6 py-4 bg-white dark:bg-white/10 rounded-b-lg">
             <div className={`font-bold ${roleText}`}>{messageContent}</div>
           </div>
         </>

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -142,7 +142,7 @@ export const Menu = ({ isPortrait }: { isPortrait?: boolean }) => {
                 <span className="text-2xl font-light tracking-[0.2em] text-secondary font-Montserrat leading-tight">
                   TONaRi
                 </span>
-                <span className="text-[7px] text-gray-400 tracking-[0.08em] font-light font-Montserrat">
+                <span className="text-[7px] text-gray-400 dark:text-gray-500 tracking-[0.08em] font-light font-Montserrat">
                   An AI Agent Standing With You
                 </span>
               </div>

--- a/src/components/messageInput.tsx
+++ b/src/components/messageInput.tsx
@@ -262,11 +262,11 @@ export const MessageInput = ({
 
   return (
     <div className="w-full flex-shrink-0">
-      <div className="bg-base-light text-black">
+      <div className="bg-base-light text-black dark:text-gray-200">
         <div className="mx-auto max-w-4xl p-4 pb-3">
           {/* エラーメッセージ表示 */}
           {fileError && (
-            <div className="mb-2 p-2 bg-red-100 border border-red-300 text-red-700 rounded-lg text-sm">
+            <div className="mb-2 p-2 bg-red-100 dark:bg-red-900/30 border border-red-300 dark:border-red-700 text-red-700 dark:text-red-300 rounded-lg text-sm">
               {fileError}
             </div>
           )}
@@ -275,7 +275,7 @@ export const MessageInput = ({
           {/* 画像プレビュー */}
           {modalImage && (
             <div
-              className="mb-2 p-2 bg-gray-100 rounded-lg relative"
+              className="mb-2 p-2 bg-gray-100 dark:bg-gray-800 rounded-lg relative"
               onDragOver={handleDragOver}
               onDrop={handleDrop}
             >
@@ -307,7 +307,7 @@ export const MessageInput = ({
                 onDragOver={handleDragOver}
                 onDrop={handleDrop}
                 disabled={chatProcessing}
-                className="bg-white hover:bg-white-hover focus:bg-white focus:ring-2 focus:ring-secondary focus:outline-none disabled:bg-gray-100 disabled:text-primary-disabled disabled:cursor-not-allowed rounded-2xl w-full px-4 text-theme-default font-bold transition-all duration-200"
+                className="bg-white dark:bg-white/10 hover:bg-white-hover focus:bg-white dark:focus:bg-white/15 focus:ring-2 focus:ring-secondary focus:outline-none disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:text-primary-disabled disabled:cursor-not-allowed rounded-2xl w-full px-4 text-theme-default font-bold transition-all duration-200"
                 value={userMessage}
                 rows={rows}
                 aria-label={t('EnterYourQuestion')}

--- a/src/components/mobileHeader.tsx
+++ b/src/components/mobileHeader.tsx
@@ -41,7 +41,7 @@ export const MobileHeader = ({ showLogo }: { showLogo?: boolean }) => {
             <span className="text-2xl font-light tracking-[0.2em] text-secondary font-Montserrat leading-tight">
               TONaRi
             </span>
-            <span className="text-[7px] text-gray-400 tracking-[0.08em] font-light font-Montserrat">
+            <span className="text-[7px] text-gray-400 dark:text-gray-500 tracking-[0.08em] font-light font-Montserrat">
               An AI Agent Standing With You
             </span>
           </div>

--- a/src/components/pomodoroSettings.tsx
+++ b/src/components/pomodoroSettings.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from 'react'
 import pomodoroStore from '@/features/stores/pomodoro'
+import settingsStore from '@/features/stores/settings'
 
 interface PomodoroSettingsProps {
   onClose: () => void
@@ -48,17 +49,19 @@ const ScrollNumberInput = ({
   return (
     <div className={`${disabled ? 'opacity-40 pointer-events-none' : ''}`}>
       <div className="flex items-center justify-between mb-1.5">
-        <span className="text-[#5c4b7d] text-sm font-medium">{label}</span>
+        <span className="text-[#5c4b7d] dark:text-[#c9b8e8] text-sm font-medium">
+          {label}
+        </span>
       </div>
       <div
         ref={containerRef}
-        className="flex items-center justify-center gap-2 bg-[#5c4b7d]/[0.03] rounded-xl py-2 px-3 group"
+        className="flex items-center justify-center gap-2 bg-[#5c4b7d]/[0.03] dark:bg-[#c9b8e8]/[0.06] rounded-xl py-2 px-3 group"
         onWheel={handleWheel}
       >
         <button
           onClick={decrement}
           disabled={disabled || value <= min}
-          className="w-8 h-8 flex items-center justify-center rounded-lg bg-[#5c4b7d]/[0.06] text-[#5c4b7d]/50 hover:bg-[#5c4b7d]/15 hover:text-[#5c4b7d] active:bg-[#5c4b7d]/20 transition-all disabled:opacity-20 disabled:hover:bg-[#5c4b7d]/[0.06] text-lg select-none"
+          className="w-8 h-8 flex items-center justify-center rounded-lg bg-[#5c4b7d]/[0.06] dark:bg-[#c9b8e8]/[0.08] text-[#5c4b7d]/50 dark:text-[#c9b8e8]/50 hover:bg-[#5c4b7d]/15 dark:hover:bg-[#c9b8e8]/15 hover:text-[#5c4b7d] dark:hover:text-[#c9b8e8] active:bg-[#5c4b7d]/20 dark:active:bg-[#c9b8e8]/20 transition-all disabled:opacity-20 disabled:hover:bg-[#5c4b7d]/[0.06] dark:disabled:hover:bg-[#c9b8e8]/[0.08] text-lg select-none"
         >
           &#x25BC;
         </button>
@@ -73,16 +76,16 @@ const ScrollNumberInput = ({
               if (!isNaN(val) && val >= min && val <= max) onChange(val)
             }}
             disabled={disabled}
-            className="w-10 bg-transparent text-right text-[#5c4b7d] font-Montserrat text-2xl font-light disabled:opacity-40 focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+            className="w-10 bg-transparent text-right text-[#5c4b7d] dark:text-[#c9b8e8] font-Montserrat text-2xl font-light disabled:opacity-40 focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
           />
-          <span className="text-[#5c4b7d]/60 text-xs font-Montserrat ml-1 w-14">
+          <span className="text-[#5c4b7d]/60 dark:text-[#c9b8e8]/60 text-xs font-Montserrat ml-1 w-14">
             {unit}
           </span>
         </div>
         <button
           onClick={increment}
           disabled={disabled || value >= max}
-          className="w-8 h-8 flex items-center justify-center rounded-lg bg-[#5c4b7d]/[0.06] text-[#5c4b7d]/50 hover:bg-[#5c4b7d]/15 hover:text-[#5c4b7d] active:bg-[#5c4b7d]/20 transition-all disabled:opacity-20 disabled:hover:bg-[#5c4b7d]/[0.06] text-lg select-none"
+          className="w-8 h-8 flex items-center justify-center rounded-lg bg-[#5c4b7d]/[0.06] dark:bg-[#c9b8e8]/[0.08] text-[#5c4b7d]/50 dark:text-[#c9b8e8]/50 hover:bg-[#5c4b7d]/15 dark:hover:bg-[#c9b8e8]/15 hover:text-[#5c4b7d] dark:hover:text-[#c9b8e8] active:bg-[#5c4b7d]/20 dark:active:bg-[#c9b8e8]/20 transition-all disabled:opacity-20 disabled:hover:bg-[#5c4b7d]/[0.06] dark:disabled:hover:bg-[#c9b8e8]/[0.08] text-lg select-none"
         >
           &#x25B2;
         </button>
@@ -105,6 +108,8 @@ export const PomodoroSettings = ({
   const phase = pomodoroStore((s) => s.phase)
   const isRunning = pomodoroStore((s) => s.isRunning)
 
+  const isDark = settingsStore((s) => s.colorTheme === 'tonari-dark')
+
   const isTimerActive =
     isRunning ||
     (phase !== 'idle' && phase !== 'completed' && phase !== 'paused')
@@ -113,21 +118,26 @@ export const PomodoroSettings = ({
     <div
       className="rounded-2xl p-6 text-sm w-80"
       style={{
-        backgroundColor: 'rgba(255, 255, 255, 0.55)',
+        backgroundColor: isDark
+          ? 'rgba(20, 20, 35, 0.75)'
+          : 'rgba(255, 255, 255, 0.55)',
         backdropFilter: 'blur(20px) saturate(1.4)',
         WebkitBackdropFilter: 'blur(20px) saturate(1.4)',
-        border: '1px solid rgba(255, 255, 255, 0.5)',
-        boxShadow:
-          '0 8px 32px rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.4)',
+        border: isDark
+          ? '1px solid rgba(255, 255, 255, 0.1)'
+          : '1px solid rgba(255, 255, 255, 0.5)',
+        boxShadow: isDark
+          ? '0 8px 32px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.05)'
+          : '0 8px 32px rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.4)',
       }}
     >
       <div className="flex justify-between items-center mb-6">
-        <span className="font-Montserrat font-light text-lg tracking-[0.1em] text-[#5c4b7d]">
+        <span className="font-Montserrat font-light text-lg tracking-[0.1em] text-[#5c4b7d] dark:text-[#c9b8e8]">
           Settings
         </span>
         <button
           onClick={onClose}
-          className="w-8 h-8 flex items-center justify-center rounded-full text-[#5c4b7d]/40 hover:text-[#5c4b7d] hover:bg-[#5c4b7d]/10 transition-colors"
+          className="w-8 h-8 flex items-center justify-center rounded-full text-[#5c4b7d]/40 dark:text-[#c9b8e8]/40 hover:text-[#5c4b7d] dark:hover:text-[#c9b8e8] hover:bg-[#5c4b7d]/10 dark:hover:bg-[#c9b8e8]/10 transition-colors"
         >
           ✕
         </button>
@@ -170,9 +180,9 @@ export const PomodoroSettings = ({
           label="Sessions"
         />
 
-        <div className="border-t border-[#5c4b7d]/10 pt-3 space-y-3">
+        <div className="border-t border-[#5c4b7d]/10 dark:border-[#c9b8e8]/10 pt-3 space-y-3">
           <div className="flex items-center justify-between">
-            <span className="text-[#5c4b7d] text-sm font-medium">
+            <span className="text-[#5c4b7d] dark:text-[#c9b8e8] text-sm font-medium">
               Auto Start
             </span>
             <button
@@ -182,7 +192,9 @@ export const PomodoroSettings = ({
                 })
               }}
               className={`w-12 h-7 rounded-full transition-colors flex-shrink-0 ${
-                autoStart ? 'bg-[#5c4b7d]' : 'bg-[#5c4b7d]/15'
+                autoStart
+                  ? 'bg-[#5c4b7d] dark:bg-[#c9b8e8]'
+                  : 'bg-[#5c4b7d]/15 dark:bg-[#c9b8e8]/15'
               }`}
             >
               <div
@@ -194,7 +206,9 @@ export const PomodoroSettings = ({
           </div>
 
           <div className="flex items-center justify-between">
-            <span className="text-[#5c4b7d] text-sm font-medium">Overlay</span>
+            <span className="text-[#5c4b7d] dark:text-[#c9b8e8] text-sm font-medium">
+              Overlay
+            </span>
             <button
               onClick={() => {
                 pomodoroStore.getState().updateSettings({
@@ -202,7 +216,9 @@ export const PomodoroSettings = ({
                 })
               }}
               className={`w-12 h-7 rounded-full transition-colors flex-shrink-0 ${
-                showOverlay ? 'bg-[#5c4b7d]' : 'bg-[#5c4b7d]/15'
+                showOverlay
+                  ? 'bg-[#5c4b7d] dark:bg-[#c9b8e8]'
+                  : 'bg-[#5c4b7d]/15 dark:bg-[#c9b8e8]/15'
               }`}
             >
               <div
@@ -217,10 +233,10 @@ export const PomodoroSettings = ({
             className={`${!showOverlay ? 'opacity-40 pointer-events-none' : ''}`}
           >
             <div className="flex items-center justify-between mb-1.5">
-              <span className="text-[#5c4b7d] text-sm font-medium">
+              <span className="text-[#5c4b7d] dark:text-[#c9b8e8] text-sm font-medium">
                 Opacity
               </span>
-              <span className="text-[#5c4b7d]/60 text-xs font-Montserrat">
+              <span className="text-[#5c4b7d]/60 dark:text-[#c9b8e8]/60 text-xs font-Montserrat">
                 {overlayOpacity}%
               </span>
             </div>
@@ -234,14 +250,16 @@ export const PomodoroSettings = ({
                   overlayOpacity: parseInt(e.target.value, 10),
                 })
               }}
-              className="w-full h-1.5 rounded-full appearance-none cursor-pointer bg-[#5c4b7d]/15 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[#5c4b7d] [&::-webkit-slider-thumb]:shadow-sm [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-[#5c4b7d] [&::-moz-range-thumb]:border-0"
+              className="w-full h-1.5 rounded-full appearance-none cursor-pointer bg-[#5c4b7d]/15 dark:bg-[#c9b8e8]/15 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[#5c4b7d] dark:[&::-webkit-slider-thumb]:bg-[#c9b8e8] [&::-webkit-slider-thumb]:shadow-sm [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-[#5c4b7d] dark:[&::-moz-range-thumb]:bg-[#c9b8e8] [&::-moz-range-thumb]:border-0"
             />
           </div>
 
           <div>
             <div className="flex items-center justify-between mb-1.5">
-              <span className="text-[#5c4b7d] text-sm font-medium">Volume</span>
-              <span className="text-[#5c4b7d]/60 text-xs font-Montserrat">
+              <span className="text-[#5c4b7d] dark:text-[#c9b8e8] text-sm font-medium">
+                Volume
+              </span>
+              <span className="text-[#5c4b7d]/60 dark:text-[#c9b8e8]/60 text-xs font-Montserrat">
                 {volume}%
               </span>
             </div>
@@ -255,13 +273,13 @@ export const PomodoroSettings = ({
                   volume: parseInt(e.target.value, 10),
                 })
               }}
-              className="w-full h-1.5 rounded-full appearance-none cursor-pointer bg-[#5c4b7d]/15 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[#5c4b7d] [&::-webkit-slider-thumb]:shadow-sm [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-[#5c4b7d] [&::-moz-range-thumb]:border-0"
+              className="w-full h-1.5 rounded-full appearance-none cursor-pointer bg-[#5c4b7d]/15 dark:bg-[#c9b8e8]/15 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[#5c4b7d] dark:[&::-webkit-slider-thumb]:bg-[#c9b8e8] [&::-webkit-slider-thumb]:shadow-sm [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-[#5c4b7d] dark:[&::-moz-range-thumb]:bg-[#c9b8e8] [&::-moz-range-thumb]:border-0"
             />
           </div>
 
           <button
             onClick={onResetLayout}
-            className="w-full py-2 rounded-xl text-[#5c4b7d]/50 text-xs hover:text-[#5c4b7d] hover:bg-[#5c4b7d]/[0.06] active:bg-[#5c4b7d]/10 transition-colors"
+            className="w-full py-2 rounded-xl text-[#5c4b7d]/50 dark:text-[#c9b8e8]/50 text-xs hover:text-[#5c4b7d] dark:hover:text-[#c9b8e8] hover:bg-[#5c4b7d]/[0.06] dark:hover:bg-[#c9b8e8]/[0.06] active:bg-[#5c4b7d]/10 dark:active:bg-[#c9b8e8]/10 transition-colors"
           >
             Reset Position & Size
           </button>

--- a/src/components/pomodoroTimer.tsx
+++ b/src/components/pomodoroTimer.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import Image from 'next/image'
 import pomodoroStore, { PomodoroPhase } from '@/features/stores/pomodoro'
+import settingsStore from '@/features/stores/settings'
 import { CircularProgress } from './circularProgress'
 import { PomodoroSettings } from './pomodoroSettings'
 
@@ -8,8 +9,10 @@ const SECONDARY = '#5c4b7d'
 const BREAK_COLOR = '#8b7aab'
 const ACTIVE_SESSION_COLOR = '#cc3355'
 
-const ICON_FILTER =
+const ICON_FILTER_LIGHT =
   'brightness(0) saturate(100%) invert(30%) sepia(15%) saturate(1200%) hue-rotate(230deg)'
+const ICON_FILTER_DARK =
+  'brightness(0) saturate(100%) invert(70%) sepia(15%) saturate(800%) hue-rotate(230deg)'
 
 const STORAGE_KEY = 'tonari-pomodoro-layout'
 const BASE_SIZE = 180
@@ -78,6 +81,7 @@ export const PomodoroTimer = () => {
   const isRunning = pomodoroStore((s) => s.isRunning)
   const showOverlay = pomodoroStore((s) => s.showOverlay)
   const overlayOpacity = pomodoroStore((s) => s.overlayOpacity)
+  const isDark = settingsStore((s) => s.colorTheme === 'tonari-dark')
 
   const [showSettings, setShowSettings] = useState(false)
   const [settingsVisible, setSettingsVisible] = useState(false)
@@ -290,6 +294,7 @@ export const PomodoroTimer = () => {
   const circleSize = Math.round(BASE_SIZE * scale)
   const iconSize = Math.round(22 * scale)
   const showHandle = isHovered && !isDragging
+  const iconFilter = isDark ? ICON_FILTER_DARK : ICON_FILTER_LIGHT
 
   return (
     <>
@@ -301,15 +306,23 @@ export const PomodoroTimer = () => {
           cursor: isDragging ? 'grabbing' : 'grab',
           padding: showOverlay ? 20 : 0,
           backgroundColor: showOverlay
-            ? `rgba(255, 255, 255, ${overlayOpacity / 100})`
+            ? isDark
+              ? `rgba(20, 20, 35, ${overlayOpacity / 100})`
+              : `rgba(255, 255, 255, ${overlayOpacity / 100})`
             : 'transparent',
           backdropFilter: showOverlay ? 'blur(20px) saturate(1.4)' : 'none',
           WebkitBackdropFilter: showOverlay
             ? 'blur(20px) saturate(1.4)'
             : 'none',
-          border: showOverlay ? '1px solid rgba(255, 255, 255, 0.5)' : 'none',
+          border: showOverlay
+            ? isDark
+              ? '1px solid rgba(255, 255, 255, 0.1)'
+              : '1px solid rgba(255, 255, 255, 0.5)'
+            : 'none',
           boxShadow: showOverlay
-            ? '0 8px 32px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.4)'
+            ? isDark
+              ? '0 8px 32px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.05)'
+              : '0 8px 32px rgba(0, 0, 0, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.4)'
             : 'none',
           opacity: timerVisible ? 1 : 0,
           transition: `opacity ${FADE_DURATION}ms ease`,
@@ -410,7 +423,7 @@ export const PomodoroTimer = () => {
                   alt={isRunning ? '一時停止' : '再開'}
                   width={iconSize}
                   height={iconSize}
-                  style={{ filter: ICON_FILTER }}
+                  style={{ filter: iconFilter }}
                 />
               </button>
 
@@ -431,7 +444,7 @@ export const PomodoroTimer = () => {
                   alt="スキップ"
                   width={iconSize}
                   height={iconSize}
-                  style={{ filter: ICON_FILTER }}
+                  style={{ filter: iconFilter }}
                 />
               </button>
 
@@ -445,7 +458,7 @@ export const PomodoroTimer = () => {
                   alt="リセット"
                   width={iconSize}
                   height={iconSize}
-                  style={{ filter: ICON_FILTER }}
+                  style={{ filter: iconFilter }}
                 />
               </button>
 
@@ -466,7 +479,7 @@ export const PomodoroTimer = () => {
                   alt="設定"
                   width={iconSize}
                   height={iconSize}
-                  style={{ filter: ICON_FILTER }}
+                  style={{ filter: iconFilter }}
                 />
               </button>
             </>
@@ -495,7 +508,7 @@ export const PomodoroTimer = () => {
           >
             <path
               d="M14 2L2 14M14 6L6 14M14 10L10 14"
-              stroke="#5c4b7d"
+              stroke={isDark ? '#9d8dbd' : '#5c4b7d'}
               strokeWidth="1.5"
               strokeLinecap="round"
               strokeOpacity="0.4"

--- a/src/components/settings/based.tsx
+++ b/src/components/settings/based.tsx
@@ -4,8 +4,10 @@ import { TextButton } from '../textButton'
 
 const Based = () => {
   const { t } = useTranslation()
+  const colorTheme = settingsStore((s) => s.colorTheme)
   const voiceEnabled = settingsStore((s) => s.voiceEnabled)
   const voiceModel = settingsStore((s) => s.voiceModel)
+  const isDark = colorTheme === 'tonari-dark'
 
   return (
     <>
@@ -21,6 +23,22 @@ const Based = () => {
             }}
           />
           <h2 className="text-2xl font-bold">{t('BasedSettings')}</h2>
+        </div>
+      </div>
+
+      {/* ダークモード設定 */}
+      <div className="my-6">
+        <div className="my-4 text-xl font-bold">Dark Mode</div>
+        <div className="my-2">
+          <TextButton
+            onClick={() =>
+              settingsStore.setState({
+                colorTheme: isDark ? 'tonari' : 'tonari-dark',
+              })
+            }
+          >
+            {isDark ? 'ON' : 'OFF'}
+          </TextButton>
         </div>
       </div>
 

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -13,7 +13,7 @@ type Props = {
 }
 const Settings = (props: Props) => {
   return (
-    <div className="fixed inset-0 z-40 bg-white/80 backdrop-blur">
+    <div className="fixed inset-0 z-40 bg-white/80 dark:bg-gray-900/90 backdrop-blur">
       <Header {...props} />
       <Main />
     </div>
@@ -144,7 +144,7 @@ const Main = () => {
           {/* モバイル版ドロップダウンナビゲーション */}
           <div className="md:hidden mb-4 relative" ref={dropdownRef}>
             <button
-              className="flex items-center justify-between w-full py-3 px-4 font-medium text-left bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+              className="flex items-center justify-between w-full py-3 px-4 font-medium text-left bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
               onClick={() => setIsDropdownOpen(!isDropdownOpen)}
             >
               <div className="flex items-center">
@@ -175,11 +175,11 @@ const Main = () => {
             </button>
 
             {isDropdownOpen && (
-              <div className="absolute top-full left-0 w-full mt-1 bg-white border border-gray-300 rounded-lg shadow-lg z-10 max-h-80 overflow-y-auto">
+              <div className="absolute top-full left-0 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg z-10 max-h-80 overflow-y-auto">
                 {tabs.map((tab) => (
                   <button
                     key={tab.key}
-                    className={`flex items-center w-full py-3 px-4 text-left hover:bg-gray-50 ${activeTab === tab.key ? 'bg-primary text-theme' : ''}`}
+                    className={`flex items-center w-full py-3 px-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700 ${activeTab === tab.key ? 'bg-primary text-theme' : ''}`}
                     onClick={() => setActiveTab(tab.key)}
                   >
                     <div
@@ -203,7 +203,7 @@ const Main = () => {
           </div>
 
           {/* タブコンテンツ */}
-          <div className="p-6 bg-gray-400 bg-opacity-20 text-medium rounded-lg w-full">
+          <div className="p-6 bg-gray-400/20 dark:bg-gray-700/30 text-medium rounded-lg w-full">
             {renderTabContent()}
           </div>
         </div>

--- a/src/components/toast.tsx
+++ b/src/components/toast.tsx
@@ -53,7 +53,7 @@ export const Toast = ({
 
   return (
     <div
-      className={`cursor-pointer top-4 right-4 p-4 rounded-2xl text-text1 shadow-lg text-sm flex items-center justify-between mb-2 bg-white bg-opacity-80 transition-opacity duration-300 ${
+      className={`cursor-pointer top-4 right-4 p-4 rounded-2xl text-text1 shadow-lg text-sm flex items-center justify-between mb-2 bg-white dark:bg-gray-800 bg-opacity-80 dark:bg-opacity-90 transition-opacity duration-300 ${
         closing ? 'opacity-0' : 'opacity-100'
       }`}
     >

--- a/src/components/vrmViewer.tsx
+++ b/src/components/vrmViewer.tsx
@@ -6,6 +6,16 @@ import settingsStore from '@/features/stores/settings'
 export default function VrmViewer() {
   const containerRef = useRef<HTMLDivElement>(null)
 
+  // ダークモード切替時にVRMライティングを調整
+  useEffect(() => {
+    const unsub = settingsStore.subscribe((state) => {
+      const { viewer } = homeStore.getState()
+      const isDark = state.colorTheme === 'tonari-dark'
+      viewer.updateLightingIntensity(isDark ? 0.3 : 1.0)
+    })
+    return () => unsub()
+  }, [])
+
   // ResizeObserverでコンテナサイズの変更を検知
   useEffect(() => {
     const container = containerRef.current
@@ -26,8 +36,9 @@ export default function VrmViewer() {
   const canvasRef = useCallback((canvas: HTMLCanvasElement) => {
     if (canvas) {
       const { viewer } = homeStore.getState()
-      const { selectedVrmPath } = settingsStore.getState()
+      const { selectedVrmPath, colorTheme } = settingsStore.getState()
       viewer.setup(canvas)
+      viewer.updateLightingIntensity(colorTheme === 'tonari-dark' ? 0.3 : 1.0)
       viewer.loadVrm(selectedVrmPath)
 
       // Drag and DropでVRMを差し替え

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -39,7 +39,7 @@ interface General {
   maxPastMessages: number
   useVideoAsBackground: boolean
   showPresetQuestions: boolean
-  colorTheme: 'tonari'
+  colorTheme: 'tonari' | 'tonari-dark'
   enableAutoCapture: boolean
   voiceEnabled: boolean
   voiceModel: 'Tomoko' | 'Kazuha'

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -16,6 +16,11 @@ export default function Document() {
         />
       </Head>
       <body>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var d=JSON.parse(localStorage.getItem('aitube-kit-settings')||'{}');var t=(d.state&&d.state.colorTheme)||'tonari';if(t==='tonari-dark'){document.documentElement.classList.add('dark');document.documentElement.setAttribute('data-theme','tonari-dark');document.documentElement.style.backgroundColor='#0f0f1a'}}catch(e){}})()`,
+          }}
+        />
         <Main />
         <NextScript />
       </body>

--- a/src/pages/admin/diary.tsx
+++ b/src/pages/admin/diary.tsx
@@ -63,7 +63,7 @@ export default function AdminDiary() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-100 dark:bg-gray-900 flex items-center justify-center">
         <div className="flex gap-2">
           {[0, 1, 2].map((i) => (
             <div
@@ -98,8 +98,8 @@ export default function AdminDiary() {
       <Head>
         <title>日記管理 - TONaRi</title>
       </Head>
-      <div className="min-h-screen bg-gray-100">
-        <header className="bg-white shadow">
+      <div className="min-h-screen bg-gray-100 dark:bg-gray-900">
+        <header className="bg-white dark:bg-gray-800 shadow">
           <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
             <div className="flex items-center gap-2">
               <svg
@@ -115,17 +115,17 @@ export default function AdminDiary() {
                   d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
                 />
               </svg>
-              <span className="text-sm font-medium text-gray-600 tracking-wider">
+              <span className="text-sm font-medium text-gray-600 dark:text-gray-300 tracking-wider">
                 DIARY
               </span>
             </div>
             <button
               onClick={() => router.push('/admin')}
-              className="w-10 h-10 rounded-full hover:bg-gray-100 flex items-center justify-center transition-colors"
+              className="w-10 h-10 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center justify-center transition-colors"
               title="戻る"
             >
               <svg
-                className="w-5 h-5 text-gray-500"
+                className="w-5 h-5 text-gray-500 dark:text-gray-400"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -143,11 +143,11 @@ export default function AdminDiary() {
 
         <main className="max-w-7xl mx-auto px-4 py-6">
           {error && (
-            <div className="mb-4 p-3 bg-red-100 text-red-700 rounded-lg">
+            <div className="mb-4 p-3 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-lg">
               {error}
               <button
                 onClick={() => setError('')}
-                className="ml-2 text-red-800 font-bold"
+                className="ml-2 text-red-800 dark:text-red-200 font-bold"
               >
                 ×
               </button>
@@ -155,29 +155,29 @@ export default function AdminDiary() {
           )}
 
           {diaries.length === 0 ? (
-            <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500">
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-8 text-center text-gray-500 dark:text-gray-400">
               まだ日記がありません
             </div>
           ) : (
-            <div className="bg-white rounded-lg shadow divide-y divide-gray-200">
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow divide-y divide-gray-200 dark:divide-gray-700">
               {diaries.map((diary) => (
                 <button
                   key={diary.date}
                   onClick={() => fetchDiaryDetail(diary.date)}
-                  className="w-full px-4 py-4 text-left hover:bg-gray-50 transition-colors flex items-center justify-between gap-3"
+                  className="w-full px-4 py-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center justify-between gap-3"
                 >
                   <div className="min-w-0">
-                    <p className="font-medium text-gray-900">
+                    <p className="font-medium text-gray-900 dark:text-gray-100">
                       {formatDate(diary.date)}
                     </p>
                     {diary.body && (
-                      <p className="text-sm text-gray-500 mt-1 truncate">
+                      <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 truncate">
                         {truncate(diary.body, 60)}
                       </p>
                     )}
                   </div>
                   <svg
-                    className="w-5 h-5 text-gray-400 flex-shrink-0"
+                    className="w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -203,7 +203,7 @@ export default function AdminDiary() {
           onClick={() => setSelectedDiary(null)}
         >
           <div
-            className="bg-white rounded-xl max-w-lg w-full max-h-[80vh] overflow-y-auto"
+            className="bg-white dark:bg-gray-800 rounded-xl max-w-lg w-full max-h-[80vh] overflow-y-auto"
             onClick={(e) => e.stopPropagation()}
           >
             {isLoadingDetail ? (
@@ -224,15 +224,15 @@ export default function AdminDiary() {
             ) : (
               <div className="p-6">
                 <div className="flex items-start justify-between mb-4">
-                  <p className="text-lg font-bold text-gray-900">
+                  <p className="text-lg font-bold text-gray-900 dark:text-gray-100">
                     {formatDate(selectedDiary.date)}
                   </p>
                   <button
                     onClick={() => setSelectedDiary(null)}
-                    className="w-8 h-8 rounded-full hover:bg-gray-100 flex items-center justify-center"
+                    className="w-8 h-8 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center justify-center"
                   >
                     <svg
-                      className="w-5 h-5 text-gray-400"
+                      className="w-5 h-5 text-gray-400 dark:text-gray-500"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
@@ -247,7 +247,7 @@ export default function AdminDiary() {
                   </button>
                 </div>
 
-                <div className="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed">
+                <div className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap leading-relaxed">
                   {selectedDiary.body}
                 </div>
               </div>

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -52,8 +52,8 @@ export default function AdminMenu() {
       <Head>
         <title>管理画面 - TONaRi</title>
       </Head>
-      <div className="min-h-screen bg-gray-100">
-        <header className="bg-white shadow">
+      <div className="min-h-screen bg-gray-100 dark:bg-gray-900">
+        <header className="bg-white dark:bg-gray-800 shadow">
           <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
             <div className="flex items-center gap-2">
               <svg
@@ -75,17 +75,17 @@ export default function AdminMenu() {
                   d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
                 />
               </svg>
-              <span className="text-sm font-medium text-gray-600 tracking-wider">
+              <span className="text-sm font-medium text-gray-600 dark:text-gray-300 tracking-wider">
                 ADMIN
               </span>
             </div>
             <button
               onClick={() => router.push('/')}
-              className="w-10 h-10 rounded-full hover:bg-gray-100 flex items-center justify-center transition-colors"
+              className="w-10 h-10 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center justify-center transition-colors"
               title="戻る"
             >
               <svg
-                className="w-5 h-5 text-gray-500"
+                className="w-5 h-5 text-gray-500 dark:text-gray-400"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -107,14 +107,14 @@ export default function AdminMenu() {
               <button
                 key={item.href}
                 onClick={() => router.push(item.href)}
-                className="bg-white rounded-lg shadow hover:shadow-md transition-shadow p-6 text-left flex items-start gap-4"
+                className="bg-white dark:bg-gray-800 rounded-lg shadow hover:shadow-md transition-shadow p-6 text-left flex items-start gap-4"
               >
                 <div className="text-secondary flex-shrink-0">{item.icon}</div>
                 <div>
-                  <h2 className="text-lg font-bold text-gray-900">
+                  <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100">
                     {item.title}
                   </h2>
-                  <p className="text-sm text-gray-500 mt-1">
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
                     {item.description}
                   </p>
                 </div>

--- a/src/pages/admin/perfumes.tsx
+++ b/src/pages/admin/perfumes.tsx
@@ -258,7 +258,7 @@ export default function AdminPerfumes() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-100 dark:bg-gray-900 flex items-center justify-center">
         <div className="flex gap-2">
           {[0, 1, 2].map((i) => (
             <div
@@ -293,8 +293,8 @@ export default function AdminPerfumes() {
       <Head>
         <title>香水データ管理 - TONaRi</title>
       </Head>
-      <div className="min-h-screen bg-gray-100">
-        <header className="bg-white shadow">
+      <div className="min-h-screen bg-gray-100 dark:bg-gray-900">
+        <header className="bg-white dark:bg-gray-800 shadow">
           <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
             <div className="flex items-center gap-2">
               <svg
@@ -310,17 +310,17 @@ export default function AdminPerfumes() {
                   d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"
                 />
               </svg>
-              <span className="text-sm font-medium text-gray-600 tracking-wider">
+              <span className="text-sm font-medium text-gray-600 dark:text-gray-300 tracking-wider">
                 PERFUMES
               </span>
             </div>
             <button
               onClick={handleBack}
-              className="w-10 h-10 rounded-full hover:bg-gray-100 flex items-center justify-center transition-colors"
+              className="w-10 h-10 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center justify-center transition-colors"
               title="戻る"
             >
               <svg
-                className="w-5 h-5 text-gray-500"
+                className="w-5 h-5 text-gray-500 dark:text-gray-400"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -338,11 +338,11 @@ export default function AdminPerfumes() {
 
         <main className="max-w-7xl mx-auto px-4 py-6">
           {error && (
-            <div className="mb-4 p-3 bg-red-100 text-red-700 rounded-lg">
+            <div className="mb-4 p-3 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-lg">
               {error}
               <button
                 onClick={() => setError('')}
-                className="ml-2 text-red-800 font-bold"
+                className="ml-2 text-red-800 dark:text-red-200 font-bold"
               >
                 ×
               </button>
@@ -374,14 +374,14 @@ export default function AdminPerfumes() {
           )}
 
           {showForm && (
-            <div className="mb-6 bg-white rounded-lg shadow p-6">
-              <h2 className="text-lg font-bold mb-4">
+            <div className="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+              <h2 className="text-lg font-bold dark:text-gray-100 mb-4">
                 {isEditing ? '香水を編集' : '新規香水を追加'}
               </h2>
               <form onSubmit={handleSubmit}>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                       ブランド名 *
                     </label>
                     <input
@@ -390,12 +390,12 @@ export default function AdminPerfumes() {
                       onChange={(e) =>
                         setFormData({ ...formData, brand: e.target.value })
                       }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded-lg"
                       required
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                       商品名 *
                     </label>
                     <input
@@ -404,12 +404,12 @@ export default function AdminPerfumes() {
                       onChange={(e) =>
                         setFormData({ ...formData, name: e.target.value })
                       }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded-lg"
                       required
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                       生産国
                     </label>
                     <input
@@ -418,11 +418,11 @@ export default function AdminPerfumes() {
                       onChange={(e) =>
                         setFormData({ ...formData, country: e.target.value })
                       }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded-lg"
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                       トップノート（カンマ区切り）
                     </label>
                     <input
@@ -431,11 +431,11 @@ export default function AdminPerfumes() {
                       onChange={(e) =>
                         setFormData({ ...formData, topNotes: e.target.value })
                       }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded-lg"
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                       ミドルノート（カンマ区切り）
                     </label>
                     <input
@@ -447,11 +447,11 @@ export default function AdminPerfumes() {
                           middleNotes: e.target.value,
                         })
                       }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded-lg"
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                       ベースノート（カンマ区切り）
                     </label>
                     <input
@@ -460,11 +460,11 @@ export default function AdminPerfumes() {
                       onChange={(e) =>
                         setFormData({ ...formData, baseNotes: e.target.value })
                       }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded-lg"
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                       評価
                     </label>
                     <select
@@ -475,7 +475,7 @@ export default function AdminPerfumes() {
                           rating: parseInt(e.target.value),
                         })
                       }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded-lg"
                     >
                       {[1, 2, 3, 4, 5].map((n) => (
                         <option key={n} value={n}>
@@ -486,7 +486,7 @@ export default function AdminPerfumes() {
                     </select>
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                       季節
                     </label>
                     <div className="flex flex-wrap gap-2">
@@ -498,7 +498,7 @@ export default function AdminPerfumes() {
                           className={`px-3 py-1 rounded-full text-sm ${
                             formData.seasons.includes(season)
                               ? 'bg-secondary text-white'
-                              : 'bg-gray-200 text-gray-700'
+                              : 'bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300'
                           }`}
                         >
                           {season}
@@ -507,7 +507,7 @@ export default function AdminPerfumes() {
                     </div>
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                       シーン
                     </label>
                     <div className="flex flex-wrap gap-2">
@@ -519,7 +519,7 @@ export default function AdminPerfumes() {
                           className={`px-3 py-1 rounded-full text-sm ${
                             formData.scenes.includes(scene)
                               ? 'bg-secondary text-white'
-                              : 'bg-gray-200 text-gray-700'
+                              : 'bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300'
                           }`}
                         >
                           {scene}
@@ -528,7 +528,7 @@ export default function AdminPerfumes() {
                     </div>
                   </div>
                   <div className="md:col-span-2">
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                       感想・コメント
                     </label>
                     <textarea
@@ -539,7 +539,7 @@ export default function AdminPerfumes() {
                           impression: e.target.value,
                         })
                       }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded-lg"
                       rows={3}
                     />
                   </div>
@@ -555,7 +555,7 @@ export default function AdminPerfumes() {
                   <button
                     type="button"
                     onClick={handleCancel}
-                    className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg hover:bg-gray-400"
+                    className="px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-400 dark:hover:bg-gray-500"
                   >
                     キャンセル
                   </button>
@@ -571,23 +571,23 @@ export default function AdminPerfumes() {
               placeholder="検索..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full md:w-64 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-secondary"
+              className="w-full md:w-64 px-4 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-secondary"
             />
           </div>
 
-          <div className="bg-white rounded-lg shadow overflow-hidden overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead className="bg-gray-50 dark:bg-gray-900">
                 <tr>
                   <th
-                    className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                    className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
                     onClick={() => handleSort('brand')}
                   >
                     ブランド
                     <SortIcon column="brand" />
                   </th>
                   <th
-                    className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                    className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
                     onClick={() => handleSort('name')}
                   >
                     商品名
@@ -607,29 +607,29 @@ export default function AdminPerfumes() {
                     評価
                     <SortIcon column="rating" />
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden lg:table-cell">
                     トップ
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden lg:table-cell">
                     ミドル
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden lg:table-cell">
                     ベース
                   </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell">
                     季節
                   </th>
-                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider w-24">
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider w-24">
                     操作
                   </th>
                 </tr>
               </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
+              <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                 {filteredPerfumes.length === 0 ? (
                   <tr>
                     <td
                       colSpan={9}
-                      className="px-4 py-8 text-center text-gray-500"
+                      className="px-4 py-8 text-center text-gray-500 dark:text-gray-400"
                     >
                       {searchQuery
                         ? '検索結果がありません'
@@ -640,16 +640,16 @@ export default function AdminPerfumes() {
                   filteredPerfumes.map((perfume) => (
                     <tr
                       key={`${perfume.brand}#${perfume.name}`}
-                      className="hover:bg-gray-50 cursor-pointer"
+                      className="hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer"
                       onClick={() => setSelectedPerfume(perfume)}
                     >
-                      <td className="px-4 py-4 text-sm text-gray-600">
+                      <td className="px-4 py-4 text-sm text-gray-600 dark:text-gray-400">
                         {perfume.brand}
                       </td>
-                      <td className="px-4 py-4 font-medium text-gray-900">
+                      <td className="px-4 py-4 font-medium text-gray-900 dark:text-gray-100">
                         {perfume.name}
                       </td>
-                      <td className="px-4 py-4 hidden md:table-cell text-sm text-gray-600">
+                      <td className="px-4 py-4 hidden md:table-cell text-sm text-gray-600 dark:text-gray-400">
                         {perfume.country || '-'}
                       </td>
                       <td className="px-4 py-4 hidden md:table-cell">
@@ -658,13 +658,13 @@ export default function AdminPerfumes() {
                           {'☆'.repeat(5 - perfume.rating)}
                         </span>
                       </td>
-                      <td className="px-4 py-4 hidden lg:table-cell text-sm text-gray-600">
+                      <td className="px-4 py-4 hidden lg:table-cell text-sm text-gray-600 dark:text-gray-400">
                         {perfume.topNotes[0] || '-'}
                       </td>
-                      <td className="px-4 py-4 hidden lg:table-cell text-sm text-gray-600">
+                      <td className="px-4 py-4 hidden lg:table-cell text-sm text-gray-600 dark:text-gray-400">
                         {perfume.middleNotes[0] || '-'}
                       </td>
-                      <td className="px-4 py-4 hidden lg:table-cell text-sm text-gray-600">
+                      <td className="px-4 py-4 hidden lg:table-cell text-sm text-gray-600 dark:text-gray-400">
                         {perfume.baseNotes[0] || '-'}
                       </td>
                       <td className="px-4 py-4 hidden md:table-cell">
@@ -672,7 +672,7 @@ export default function AdminPerfumes() {
                           {perfume.seasons.map((season) => (
                             <span
                               key={season}
-                              className="px-2 py-0.5 bg-blue-100 text-blue-800 text-xs rounded"
+                              className="px-2 py-0.5 bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 text-xs rounded"
                             >
                               {season}
                             </span>
@@ -685,7 +685,7 @@ export default function AdminPerfumes() {
                             e.stopPropagation()
                             handleEdit(perfume)
                           }}
-                          className="w-8 h-8 rounded-full hover:bg-gray-200 inline-flex items-center justify-center transition-colors mr-1"
+                          className="w-8 h-8 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex items-center justify-center transition-colors mr-1"
                           title="編集"
                         >
                           <svg
@@ -707,7 +707,7 @@ export default function AdminPerfumes() {
                             e.stopPropagation()
                             handleDelete(perfume)
                           }}
-                          className="w-8 h-8 rounded-full hover:bg-red-50 inline-flex items-center justify-center transition-colors"
+                          className="w-8 h-8 rounded-full hover:bg-red-50 dark:hover:bg-red-900/30 inline-flex items-center justify-center transition-colors"
                           title="削除"
                         >
                           <svg
@@ -741,26 +741,26 @@ export default function AdminPerfumes() {
           onClick={() => setSelectedPerfume(null)}
         >
           <div
-            className="bg-white rounded-xl max-w-lg w-full max-h-[80vh] overflow-y-auto"
+            className="bg-white dark:bg-gray-800 rounded-xl max-w-lg w-full max-h-[80vh] overflow-y-auto"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="p-6">
               <div className="flex items-start justify-between mb-4">
                 <div>
-                  <h2 className="text-xl font-bold text-gray-900">
+                  <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
                     {selectedPerfume.name}
                   </h2>
-                  <p className="text-sm text-gray-500">
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
                     {selectedPerfume.brand}
                     {selectedPerfume.country && ` / ${selectedPerfume.country}`}
                   </p>
                 </div>
                 <button
                   onClick={() => setSelectedPerfume(null)}
-                  className="w-8 h-8 rounded-full hover:bg-gray-100 flex items-center justify-center"
+                  className="w-8 h-8 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center justify-center"
                 >
                   <svg
-                    className="w-5 h-5 text-gray-400"
+                    className="w-5 h-5 text-gray-400 dark:text-gray-500"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -785,12 +785,14 @@ export default function AdminPerfumes() {
 
                 {selectedPerfume.seasons.length > 0 && (
                   <div>
-                    <p className="text-xs text-gray-400 mb-1">SEASON</p>
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">
+                      SEASON
+                    </p>
                     <div className="flex flex-wrap gap-1">
                       {selectedPerfume.seasons.map((season) => (
                         <span
                           key={season}
-                          className="px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded"
+                          className="px-2 py-1 bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 text-xs rounded"
                         >
                           {season}
                         </span>
@@ -801,12 +803,14 @@ export default function AdminPerfumes() {
 
                 {selectedPerfume.scenes.length > 0 && (
                   <div>
-                    <p className="text-xs text-gray-400 mb-1">SCENE</p>
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">
+                      SCENE
+                    </p>
                     <div className="flex flex-wrap gap-1">
                       {selectedPerfume.scenes.map((scene) => (
                         <span
                           key={scene}
-                          className="px-2 py-1 bg-purple-100 text-purple-800 text-xs rounded"
+                          className="px-2 py-1 bg-purple-100 dark:bg-purple-900/40 text-purple-800 dark:text-purple-300 text-xs rounded"
                         >
                           {scene}
                         </span>
@@ -817,8 +821,10 @@ export default function AdminPerfumes() {
 
                 {selectedPerfume.topNotes.length > 0 && (
                   <div>
-                    <p className="text-xs text-gray-400 mb-1">TOP NOTES</p>
-                    <p className="text-sm text-gray-700">
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">
+                      TOP NOTES
+                    </p>
+                    <p className="text-sm text-gray-700 dark:text-gray-300">
                       {selectedPerfume.topNotes.join(', ')}
                     </p>
                   </div>
@@ -826,8 +832,10 @@ export default function AdminPerfumes() {
 
                 {selectedPerfume.middleNotes.length > 0 && (
                   <div>
-                    <p className="text-xs text-gray-400 mb-1">MIDDLE NOTES</p>
-                    <p className="text-sm text-gray-700">
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">
+                      MIDDLE NOTES
+                    </p>
+                    <p className="text-sm text-gray-700 dark:text-gray-300">
                       {selectedPerfume.middleNotes.join(', ')}
                     </p>
                   </div>
@@ -835,8 +843,10 @@ export default function AdminPerfumes() {
 
                 {selectedPerfume.baseNotes.length > 0 && (
                   <div>
-                    <p className="text-xs text-gray-400 mb-1">BASE NOTES</p>
-                    <p className="text-sm text-gray-700">
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">
+                      BASE NOTES
+                    </p>
+                    <p className="text-sm text-gray-700 dark:text-gray-300">
                       {selectedPerfume.baseNotes.join(', ')}
                     </p>
                   </div>
@@ -844,15 +854,17 @@ export default function AdminPerfumes() {
 
                 {selectedPerfume.impression && (
                   <div>
-                    <p className="text-xs text-gray-400 mb-1">IMPRESSION</p>
-                    <p className="text-sm text-gray-700 whitespace-pre-wrap">
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">
+                      IMPRESSION
+                    </p>
+                    <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
                       {selectedPerfume.impression}
                     </p>
                   </div>
                 )}
               </div>
 
-              <div className="mt-6 pt-4 border-t flex justify-end gap-2">
+              <div className="mt-6 pt-4 border-t dark:border-gray-700 flex justify-end gap-2">
                 <button
                   onClick={() => {
                     handleEdit(selectedPerfume)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -83,6 +83,9 @@ const Home = () => {
         : `url(${buildUrl(backgroundImageUrl)})`
   const messageReceiverEnabled = settingsStore((s) => s.messageReceiverEnabled)
 
+  const colorTheme = settingsStore((s) => s.colorTheme)
+  const isDark = colorTheme === 'tonari-dark'
+
   const backgroundStyle =
     webcamStatus && useVideoAsBackground
       ? {}
@@ -90,12 +93,13 @@ const Home = () => {
         ? { backgroundColor: '#00FF00' }
         : backgroundImageUrl === 'gradient'
           ? {
-              background:
-                'linear-gradient(135deg, #f5f0e8 0%, #f0ece4 40%, #e8efe6 70%, #e0ebe0 100%)',
+              background: isDark
+                ? 'linear-gradient(135deg, #1a1a2e 0%, #1e1e35 40%, #1a2530 70%, #1a2a28 100%)'
+                : 'linear-gradient(135deg, #f5f0e8 0%, #f0ece4 40%, #e8efe6 70%, #e0ebe0 100%)',
             }
           : backgroundImageUrl
             ? { backgroundImage: bgUrl }
-            : { backgroundColor: '#E8E8E8' }
+            : { backgroundColor: isDark ? '#1a1a2e' : '#E8E8E8' }
 
   const layoutReady = isMobile !== null && isPortrait !== null
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -228,7 +228,7 @@ export default function Login() {
           )}
           <button
             onClick={() => navigateWithTransition('/')}
-            className="mt-10 text-gray-400 hover:text-gray-500 text-xs tracking-widest transition-colors login-fade-in-up"
+            className="mt-10 text-gray-400 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-400 text-xs tracking-widest transition-colors login-fade-in-up"
             style={{ animationDelay: '400ms' }}
           >
             SKIP
@@ -238,7 +238,7 @@ export default function Login() {
               href="https://github.com/n-yokomachi/tonari"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-gray-300 hover:text-gray-500 transition-colors"
+              className="text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 transition-colors"
             >
               <svg className="w-6 h-6" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
@@ -315,7 +315,7 @@ export default function Login() {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="w-full px-4 py-3 pr-12 bg-white/60 backdrop-blur border border-gray-200 rounded-lg text-gray-800 focus:outline-none focus:border-secondary transition-colors text-center tracking-widest"
+                className="w-full px-4 py-3 pr-12 bg-white/60 dark:bg-white/10 backdrop-blur border border-gray-200 dark:border-gray-600 rounded-lg text-gray-800 dark:text-gray-200 focus:outline-none focus:border-secondary transition-colors text-center tracking-widest"
                 required
                 autoFocus
               />
@@ -358,7 +358,7 @@ export default function Login() {
           {isTouchIdAvailable && hasRegisteredCredential && (
             <button
               onClick={() => setShowPasswordForm(!showPasswordForm)}
-              className="w-10 h-10 rounded-full bg-gray-300 hover:bg-gray-500 transition-colors flex items-center justify-center"
+              className="w-10 h-10 rounded-full bg-gray-300 dark:bg-gray-600 hover:bg-gray-500 dark:hover:bg-gray-500 transition-colors flex items-center justify-center"
               title="Password login"
             >
               <svg
@@ -378,7 +378,7 @@ export default function Login() {
             href="https://github.com/n-yokomachi/tonari"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-300 hover:text-gray-500 transition-colors"
+            className="text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 transition-colors"
           >
             <svg className="w-10 h-10" viewBox="0 0 24 24" fill="currentColor">
               <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
@@ -396,7 +396,7 @@ function Branding() {
       <h1 className="text-5xl font-light tracking-[0.3em] text-secondary font-Montserrat">
         TONaRi
       </h1>
-      <p className="mt-3 text-[11px] text-gray-400 tracking-[0.25em] font-light">
+      <p className="mt-3 text-[11px] text-gray-400 dark:text-gray-500 tracking-[0.25em] font-light">
         An AI Agent Standing With{' '}
         <a
           href="https://x.com/_cityside"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  background-color: var(--color-base-light);
+}
+
 body {
   background-position: top center;
   background-attachment: fixed;

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -76,3 +76,20 @@ div {
   --tonari-text: #f5f0e8;
   --tonari-accent: #e8c4a0;
 }
+
+/* ダークモード */
+.dark {
+  --color-primary: #c9a96e;
+  --color-primary-hover: #d4bf96;
+  --color-primary-press: #b89e72;
+  --color-primary-disabled: #c9a96e4d;
+  --color-secondary: #8b7aab;
+  --color-secondary-hover: #9d8dbd;
+  --color-secondary-press: #6f5d94;
+  --color-secondary-disabled: #8b7aab4d;
+  --color-text-primary: #e8dcc8;
+  --color-text-base: #ffffff;
+  --color-text-default: #e0dcd6;
+  --color-base-light: #1a1a2e;
+  --color-base-dark: #0f0f1a;
+}


### PR DESCRIPTION
## Summary
- 全画面（ログイン、トップ、設定、管理画面）およびコンポーネント（チャットログ、入力フォーム、ポモドーロタイマー、トースト等）にダークモード対応を追加
- VRMライティングをダークモード時に減光（intensity 0.3）
- `_document.tsx` にブロッキングスクリプトを追加し、ページ読み込み時の白フラッシュを防止
- テーマ切り替えがリロードなしでリアルタイム反映されるよう修正

## 変更内容
| 区分 | ファイル | 内容 |
|---|---|---|
| ストア | `settings.ts` | `colorTheme` に `tonari-dark` を追加 |
| テーマ | `themes.css` | `.dark` セレクタでCSS変数上書き |
| テーマ | `globals.css` | `html` 背景色をCSS変数で設定 |
| 初期化 | `_document.tsx` | ブロッキングスクリプトで白フラッシュ防止 |
| 初期化 | `_app.tsx` | テーマ切り替えのリアルタイム反映修正 |
| UI | `settings/based.tsx` | ダークモードトグルボタン追加 |
| UI | `settings/index.tsx`, `chatLog.tsx`, `messageInput.tsx`, `menu.tsx`, `mobileHeader.tsx`, `toast.tsx`, `cameraPreview.tsx` | `dark:` プレフィックス対応 |
| UI | `login.tsx`, `index.tsx` | ページ全体のダーク対応 |
| UI | `admin/index.tsx`, `admin/diary.tsx`, `admin/perfumes.tsx` | 管理画面のダーク対応 |
| UI | `pomodoroTimer.tsx`, `pomodoroSettings.tsx` | ガラスUIのダーク対応 |
| 3D | `vrmViewer.tsx` | ダーク時にVRMライティング減光 |

## Test plan
- [ ] 設定画面でダークモードON/OFF切り替え → リロードなしで即座に反映される
- [ ] ダークモードでページリロード → 白フラッシュなく暗い背景で表示される
- [ ] 全ページ（ログイン、トップ、設定、管理画面3種）でダーク表示を確認
- [ ] VRMモデルのライティングがダーク時に暗くなることを確認
- [ ] ポモドーロタイマー・設定のガラスUIがダークに対応していること
- [ ] ライトモードに戻しても正常に表示される

Closes #64