### PR TITLE
robots.txtでWeb検索から除外

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Summary
- `public/robots.txt` を追加し、全クローラーによるサイト全体のクロールを拒否

Closes #91