### PR TITLE
Picovoiceアクセスキーのプラットフォーム別切り替え

### DIFF
--- a/src/features/voiceInput/useWakeWordDetection.ts
+++ b/src/features/voiceInput/useWakeWordDetection.ts
@@ -185,8 +185,9 @@ export const useWakeWordDetection = () => {
 
     const initPorcupine = async () => {
       try {
-        // Fetch access key from server-side API
-        const res = await fetch('/api/picovoice-key')
+        // Detect platform and fetch appropriate access key
+        const platform = /Win/.test(navigator.platform) ? 'windows' : 'mac'
+        const res = await fetch(`/api/picovoice-key?platform=${platform}`)
         if (!res.ok) throw new Error('Failed to fetch access key')
         const { accessKey } = await res.json()
         if (aborted) return

--- a/src/pages/api/picovoice-key.ts
+++ b/src/pages/api/picovoice-key.ts
@@ -5,7 +5,19 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const accessKey = process.env.PICOVOICE_ACCESS_KEY || ''
+  const platform = (req.query.platform as string) || ''
+  let accessKey = ''
+
+  if (platform === 'windows') {
+    accessKey = process.env.PICOVOICE_ACCESS_KEY_WINDOWS || ''
+  } else if (platform === 'mac') {
+    accessKey = process.env.PICOVOICE_ACCESS_KEY_MAC || ''
+  }
+
+  // Fallback to legacy single key
+  if (!accessKey) {
+    accessKey = process.env.PICOVOICE_ACCESS_KEY || ''
+  }
 
   if (!accessKey) {
     return res


### PR DESCRIPTION
## Summary
- クライアントのプラットフォーム（Mac/Windows）を検出し、対応するPicovoiceアクセスキーを自動選択
- APIルート `/api/picovoice-key` に `platform` クエリパラメータを追加
- 環境変数を `PICOVOICE_ACCESS_KEY_MAC` / `PICOVOICE_ACCESS_KEY_WINDOWS` に分割
- 後方互換: 旧 `PICOVOICE_ACCESS_KEY` へのフォールバックあり

## Vercel環境変数の設定が必要
- `PICOVOICE_ACCESS_KEY_MAC`: Mac用アクセスキー
- `PICOVOICE_ACCESS_KEY_WINDOWS`: Windows用アクセスキー

Closes #51