### PR TITLE
UIスタイル切り替え・送信ボタンリング・Liquid Metalパープル化

### DIFF
--- a/src/components/cameraPreview.tsx
+++ b/src/components/cameraPreview.tsx
@@ -81,9 +81,36 @@ export const CameraButton = () => {
   const { t } = useTranslation()
   const chatProcessing = homeStore((s) => s.chatProcessing)
   const cameraOpen = homeStore((s) => s.cameraOpen)
+  const uiStyle = settingsStore((s) => s.uiStyle)
+  const isDark = settingsStore((s) => s.colorTheme === 'tonari-dark')
 
   if (!isCameraSupported() || cameraOpen) {
     return null
+  }
+
+  if (uiStyle === 'droplet') {
+    return (
+      <IconButton
+        iconName="24/Camera"
+        isProcessing={false}
+        disabled={chatProcessing}
+        onClick={() => homeStore.setState({ cameraOpen: true })}
+        className="!rounded-full disabled:opacity-50 disabled:cursor-not-allowed"
+        style={{
+          background: isDark
+            ? 'rgba(255,255,255,0.06)'
+            : 'rgba(255,255,255,0.15)',
+          border: isDark
+            ? '1px solid rgba(255,255,255,0.06)'
+            : '1px solid rgba(255,255,255,0.4)',
+          boxShadow: isDark
+            ? '0 1px 6px rgba(0,0,0,0.2), inset 0 1px 0 rgba(255,255,255,0.1), inset 0 -1px 0 rgba(255,255,255,0.04)'
+            : '0 1px 6px rgba(0,0,0,0.04), inset 0 1px 1px rgba(255,255,255,0.6), inset 0 -1px 1px rgba(255,255,255,0.3)',
+        }}
+        iconColor="text-gray-700 dark:text-gray-300"
+        aria-label={t('OpenCamera')}
+      />
+    )
   }
 
   return (
@@ -92,7 +119,7 @@ export const CameraButton = () => {
       isProcessing={false}
       disabled={chatProcessing}
       onClick={() => homeStore.setState({ cameraOpen: true })}
-      className="bg-transparent hover:bg-white/10 active:bg-white/20 border border-white/40 dark:border-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
+      className="!rounded-[10px] bg-transparent hover:bg-white/10 active:bg-white/20 border border-white/40 dark:border-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
       iconColor="text-gray-700 dark:text-gray-300"
       aria-label={t('OpenCamera')}
     />

--- a/src/components/liquidMetal.tsx
+++ b/src/components/liquidMetal.tsx
@@ -30,7 +30,11 @@ export const LiquidMetal = memo(function LiquidMetal({
   return (
     <div
       className={`absolute inset-0 z-0 overflow-hidden ${className ?? ''}`}
-      style={style}
+      style={{
+        ...style,
+        opacity: 0.5,
+        filter: 'sepia(1) hue-rotate(220deg) saturate(1.5)',
+      }}
     >
       <LiquidMetalShader
         colorBack={colorBack}
@@ -38,7 +42,7 @@ export const LiquidMetal = memo(function LiquidMetal({
         speed={speed}
         repetition={repetition}
         distortion={distortion}
-        softness={0}
+        softness={0.4}
         shiftRed={shiftRed}
         shiftBlue={shiftBlue}
         angle={45}

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -190,6 +190,7 @@ const TaskIconButton = () => {
 export const Menu = ({ isPortrait }: { isPortrait?: boolean }) => {
   const showControlPanel = settingsStore((s) => s.showControlPanel)
   const isDark = settingsStore((s) => s.colorTheme === 'tonari-dark')
+  const uiStyle = settingsStore((s) => s.uiStyle)
 
   const showSettings = menuStore((s) => s.showSettings)
   const setShowSettings = useCallback(
@@ -299,17 +300,34 @@ export const Menu = ({ isPortrait }: { isPortrait?: boolean }) => {
               <div
                 className="relative rounded-3xl"
                 style={{
-                  boxShadow: isDark
-                    ? '0 4px 24px rgba(0,0,0,0.3)'
-                    : '0 4px 24px rgba(0,0,0,0.08)',
+                  boxShadow:
+                    uiStyle === 'neumorphic'
+                      ? isDark
+                        ? '6px 6px 16px rgba(0,0,0,0.6), -4px -4px 12px rgba(255,255,255,0.04)'
+                        : '8px 8px 20px rgba(0,0,0,0.12), -6px -6px 16px rgba(255,255,255,0.9)'
+                      : isDark
+                        ? '0 4px 24px rgba(0,0,0,0.3)'
+                        : '0 4px 24px rgba(0,0,0,0.08)',
                 }}
               >
-                {/* Liquid Metal border frame (light mode only) */}
-                {!isDark && (
+                {/* Neumorphic: top glow accent */}
+                {uiStyle === 'neumorphic' && (
+                  <div
+                    className="absolute -top-2 left-1/4 right-1/4 h-8 z-20 pointer-events-none rounded-full"
+                    style={{
+                      background: isDark
+                        ? 'radial-gradient(ellipse at center, rgba(139,122,171,0.2) 0%, transparent 70%)'
+                        : 'radial-gradient(ellipse at center, rgba(200,180,220,0.4) 0%, rgba(255,200,200,0.15) 40%, transparent 70%)',
+                      filter: 'blur(6px)',
+                    }}
+                  />
+                )}
+                {/* Liquid Metal border frame (glass + light mode only) */}
+                {uiStyle === 'glass' && !isDark && (
                   <div
                     className="absolute inset-0 z-20 pointer-events-none rounded-3xl"
                     style={{
-                      padding: 1,
+                      padding: 2,
                       WebkitMask:
                         'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
                       WebkitMaskComposite: 'xor',
@@ -318,7 +336,7 @@ export const Menu = ({ isPortrait }: { isPortrait?: boolean }) => {
                     }}
                   >
                     <LiquidMetal
-                      colorBack="#aaaaac"
+                      colorBack="#c8c8cc"
                       colorTint="#ffffff"
                       speed={0.3}
                       repetition={6}
@@ -331,13 +349,32 @@ export const Menu = ({ isPortrait }: { isPortrait?: boolean }) => {
                 )}
                 <div
                   ref={spotlightRef}
-                  className="relative z-10 flex items-center gap-[8px] rounded-3xl px-2 py-1 bg-white/25 dark:bg-[rgba(20,20,35,0.45)] dark:border dark:border-white/10 overflow-hidden "
+                  className={`relative z-10 flex items-center gap-[8px] rounded-3xl px-2 py-1 overflow-hidden ${
+                    uiStyle === 'neumorphic'
+                      ? isDark
+                        ? 'bg-[rgba(30,30,50,0.8)] border border-white/5'
+                        : 'bg-[rgba(240,237,232,0.85)] border border-white/60'
+                      : uiStyle === 'droplet'
+                        ? isDark
+                          ? 'bg-[rgba(20,20,35,0.4)] border border-white/[0.06]'
+                          : 'bg-white/20 border border-white/40'
+                        : 'bg-white/25 dark:bg-[rgba(20,20,35,0.45)] dark:border dark:border-white/10'
+                  }`}
                   style={{
                     backdropFilter: 'blur(16px) saturate(1.6)',
                     WebkitBackdropFilter: 'blur(16px) saturate(1.6)',
-                    boxShadow: isDark
-                      ? 'inset 0 1px 0 rgba(255,255,255,0.05)'
-                      : 'inset 0 1px 0 rgba(255,255,255,0.5)',
+                    boxShadow:
+                      uiStyle === 'neumorphic'
+                        ? isDark
+                          ? 'inset 2px 2px 4px rgba(0,0,0,0.3), inset -1px -1px 3px rgba(255,255,255,0.03)'
+                          : 'inset 2px 2px 5px rgba(0,0,0,0.06), inset -2px -2px 4px rgba(255,255,255,0.8)'
+                        : uiStyle === 'droplet'
+                          ? isDark
+                            ? '0 4px 20px rgba(0,0,0,0.3), inset 0 1px 1px rgba(255,255,255,0.12), inset 0 -1px 1px rgba(255,255,255,0.06)'
+                            : '0 4px 20px rgba(0,0,0,0.06), inset 0 2px 2px rgba(255,255,255,0.7), inset 0 -2px 2px rgba(255,255,255,0.35)'
+                          : isDark
+                            ? 'inset 0 1px 0 rgba(255,255,255,0.05)'
+                            : 'inset 0 1px 0 rgba(255,255,255,0.5)',
                   }}
                 >
                   {/* Spotlight overlay */}

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -352,8 +352,8 @@ export const Menu = ({ isPortrait }: { isPortrait?: boolean }) => {
                   className={`relative z-10 flex items-center gap-[8px] rounded-3xl px-2 py-1 overflow-hidden ${
                     uiStyle === 'neumorphic'
                       ? isDark
-                        ? 'bg-[rgba(30,30,50,0.8)] border border-white/5'
-                        : 'bg-[rgba(240,237,232,0.85)] border border-white/60'
+                        ? 'bg-[rgba(20,20,35,0.3)] border border-white/5'
+                        : 'bg-white/10 border border-white/60'
                       : uiStyle === 'droplet'
                         ? isDark
                           ? 'bg-[rgba(20,20,35,0.4)] border border-white/[0.06]'
@@ -361,8 +361,14 @@ export const Menu = ({ isPortrait }: { isPortrait?: boolean }) => {
                         : 'bg-white/25 dark:bg-[rgba(20,20,35,0.45)] dark:border dark:border-white/10'
                   }`}
                   style={{
-                    backdropFilter: 'blur(16px) saturate(1.6)',
-                    WebkitBackdropFilter: 'blur(16px) saturate(1.6)',
+                    backdropFilter:
+                      uiStyle === 'neumorphic'
+                        ? 'blur(8px) saturate(1.2)'
+                        : 'blur(16px) saturate(1.6)',
+                    WebkitBackdropFilter:
+                      uiStyle === 'neumorphic'
+                        ? 'blur(8px) saturate(1.2)'
+                        : 'blur(16px) saturate(1.6)',
                     boxShadow:
                       uiStyle === 'neumorphic'
                         ? isDark

--- a/src/components/messageInput.tsx
+++ b/src/components/messageInput.tsx
@@ -7,6 +7,123 @@ import { IconButton } from './iconButton'
 import { CameraPreview, CameraButton } from './cameraPreview'
 import { LiquidMetal } from './liquidMetal'
 
+const SendButton = ({
+  isActive,
+  isProcessing,
+  disabled,
+  isDark,
+  uiStyle,
+  onClick,
+  ariaLabel,
+}: {
+  isActive: boolean
+  isProcessing: boolean
+  disabled: boolean
+  isDark: boolean
+  uiStyle: 'glass' | 'neumorphic' | 'droplet'
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void
+  ariaLabel: string
+}) => {
+  if (uiStyle === 'droplet') {
+    return (
+      <button
+        className={`rounded-full text-sm p-2.5 text-center inline-flex items-center focus:outline-none focus:ring-0 transition-all duration-300 ${
+          disabled ? 'opacity-40 cursor-not-allowed' : ''
+        }`}
+        style={{
+          background: isDark
+            ? 'rgba(255,255,255,0.06)'
+            : 'rgba(255,255,255,0.15)',
+          border: isDark
+            ? '1px solid rgba(255,255,255,0.06)'
+            : '1px solid rgba(255,255,255,0.4)',
+          boxShadow: isActive
+            ? isDark
+              ? '0 2px 12px rgba(0,0,0,0.3), inset 0 1px 1px rgba(255,255,255,0.15), inset 0 -1px 1px rgba(255,255,255,0.06)'
+              : '0 2px 12px rgba(0,0,0,0.08), inset 0 2px 2px rgba(255,255,255,0.7), inset 0 -2px 2px rgba(255,255,255,0.35)'
+            : isDark
+              ? '0 1px 6px rgba(0,0,0,0.2), inset 0 1px 0 rgba(255,255,255,0.1), inset 0 -1px 0 rgba(255,255,255,0.04)'
+              : '0 1px 6px rgba(0,0,0,0.04), inset 0 1px 1px rgba(255,255,255,0.6), inset 0 -1px 1px rgba(255,255,255,0.3)',
+        }}
+        disabled={disabled}
+        onClick={onClick}
+        aria-label={ariaLabel}
+      >
+        <Image
+          src="/images/icons/send.svg"
+          alt={ariaLabel}
+          width={24}
+          height={24}
+          priority
+          unoptimized
+          className={`transition-all duration-300 ${isProcessing ? 'animate-pulse' : ''} ${
+            isActive
+              ? isDark
+                ? 'brightness-200'
+                : 'brightness-0'
+              : isDark
+                ? 'brightness-150 opacity-40'
+                : 'opacity-30'
+          }`}
+        />
+      </button>
+    )
+  }
+
+  return (
+    <div className="relative">
+      {/* Glow layer */}
+      <div className={`gold-ring-glow ${isActive ? 'active' : ''}`} />
+      {/* Clip container + rotating gradient */}
+      <div className="gold-ring-clip">
+        <div className={`gold-ring-gradient ${isActive ? 'active' : ''}`} />
+      </div>
+      {/* Inner plate - matches glass container when inactive */}
+      <div
+        className="gold-ring-inner transition-colors duration-300"
+        style={{
+          backgroundColor: isActive
+            ? isDark
+              ? 'rgba(20,20,35,0.95)'
+              : 'rgba(255,255,255,0.9)'
+            : 'transparent',
+        }}
+      />
+      {/* Button */}
+      <button
+        className={`relative z-10 rounded-[10px] text-sm p-2 text-center inline-flex items-center focus:outline-none focus:ring-0 transition-all duration-300 ${
+          isActive
+            ? isDark
+              ? 'bg-white/40 hover:bg-white/50 active:bg-white/55'
+              : 'bg-black/5 hover:bg-black/10 active:bg-black/15'
+            : isDark
+              ? 'bg-white/5 border border-white/10'
+              : 'bg-white/30 border border-black/5'
+        } ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
+        disabled={disabled}
+        onClick={onClick}
+        aria-label={ariaLabel}
+      >
+        <Image
+          src="/images/icons/send.svg"
+          alt={ariaLabel}
+          width={24}
+          height={24}
+          priority
+          unoptimized
+          className={`transition-all duration-300 ${isProcessing ? 'animate-pulse' : ''} ${
+            isActive
+              ? 'brightness-200'
+              : isDark
+                ? 'brightness-150 opacity-40'
+                : 'opacity-30'
+          }`}
+        />
+      </button>
+    </div>
+  )
+}
+
 // ファイルバリデーションの設定
 const FILE_VALIDATION = {
   maxSizeBytes: 10 * 1024 * 1024, // 10MB
@@ -36,6 +153,7 @@ export const MessageInput = ({
   const chatProcessing = homeStore((s) => s.chatProcessing)
   const modalImage = homeStore((s) => s.modalImage)
   const isDark = settingsStore((s) => s.colorTheme === 'tonari-dark')
+  const uiStyle = settingsStore((s) => s.uiStyle)
   const [rows, setRows] = useState(1)
   const [fileError, setFileError] = useState<string>('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -265,14 +383,14 @@ export const MessageInput = ({
   return (
     <div className="w-full flex-shrink-0">
       <div className="relative">
-        {/* Liquid Metal top border only (light mode only) */}
-        {!isDark && (
+        {/* Liquid Metal top border only (glass + light mode only) */}
+        {uiStyle === 'glass' && !isDark && (
           <div
             className="absolute top-0 left-0 right-0 h-[40px] z-20 pointer-events-none"
-            style={{ clipPath: 'inset(0 0 calc(100% - 1px) 0)' }}
+            style={{ clipPath: 'inset(0 0 calc(100% - 2px) 0)' }}
           >
             <LiquidMetal
-              colorBack="#aaaaac"
+              colorBack="#c8c8cc"
               colorTint="#ffffff"
               speed={0.3}
               repetition={6}
@@ -284,13 +402,32 @@ export const MessageInput = ({
           </div>
         )}
         <div
-          className="text-black dark:text-gray-200 bg-white/25 dark:bg-[rgba(20,20,35,0.45)]"
+          className={`text-black dark:text-gray-200 ${
+            uiStyle === 'neumorphic'
+              ? isDark
+                ? 'bg-[rgba(30,30,50,0.8)] border-t border-white/5'
+                : 'bg-[rgba(240,237,232,0.85)] border-t border-white/60'
+              : uiStyle === 'droplet'
+                ? isDark
+                  ? 'bg-[rgba(20,20,35,0.4)] border-t border-white/[0.06]'
+                  : 'bg-white/20 border-t border-white/40'
+                : 'bg-white/25 dark:bg-[rgba(20,20,35,0.45)]'
+          }`}
           style={{
             backdropFilter: 'blur(16px) saturate(1.6)',
             WebkitBackdropFilter: 'blur(16px) saturate(1.6)',
-            boxShadow: isDark
-              ? '0 -4px 24px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.05)'
-              : '0 -4px 24px rgba(0,0,0,0.06), inset 0 1px 0 rgba(255,255,255,0.5)',
+            boxShadow:
+              uiStyle === 'neumorphic'
+                ? isDark
+                  ? '0 -6px 16px rgba(0,0,0,0.5), inset 0 2px 4px rgba(0,0,0,0.2), inset 0 -1px 3px rgba(255,255,255,0.03)'
+                  : '0 -8px 20px rgba(0,0,0,0.08), inset 0 2px 5px rgba(0,0,0,0.04), inset 0 -2px 4px rgba(255,255,255,0.8)'
+                : uiStyle === 'droplet'
+                  ? isDark
+                    ? '0 -4px 20px rgba(0,0,0,0.3), inset 0 1px 1px rgba(255,255,255,0.12), inset 0 -1px 1px rgba(255,255,255,0.06)'
+                    : '0 -4px 20px rgba(0,0,0,0.06), inset 0 2px 2px rgba(255,255,255,0.7), inset 0 -2px 2px rgba(255,255,255,0.35)'
+                  : isDark
+                    ? '0 -4px 24px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.05)'
+                    : '0 -4px 24px rgba(0,0,0,0.06), inset 0 1px 0 rgba(255,255,255,0.5)',
           }}
         >
           <div className="mx-auto max-w-4xl p-4 pb-3">
@@ -353,13 +490,14 @@ export const MessageInput = ({
                 <CameraButton />
               </div>
               <div className="flex-shrink-0 pb-[0.3rem]">
-                <IconButton
-                  iconName="24/Send"
-                  className="bg-secondary hover:bg-secondary-hover active:bg-secondary-press disabled:bg-secondary-disabled disabled:opacity-50 disabled:cursor-not-allowed"
+                <SendButton
+                  isActive={!chatProcessing && !!(userMessage || modalImage)}
                   isProcessing={chatProcessing}
                   disabled={chatProcessing || (!userMessage && !modalImage)}
+                  isDark={isDark}
+                  uiStyle={uiStyle}
                   onClick={onClickSendButton}
-                  aria-label={t('SendMessage.directSendTitle')}
+                  ariaLabel={t('SendMessage.directSendTitle')}
                 />
               </div>
             </div>

--- a/src/components/messageInput.tsx
+++ b/src/components/messageInput.tsx
@@ -91,14 +91,14 @@ const SendButton = ({
       />
       {/* Button */}
       <button
-        className={`relative z-10 rounded-[10px] text-sm p-2 text-center inline-flex items-center focus:outline-none focus:ring-0 transition-all duration-300 ${
+        className={`relative z-10 rounded-[10px] text-sm p-2 text-center inline-flex items-center focus:outline-none focus:ring-0 transition-all duration-300 border ${
           isActive
             ? isDark
-              ? 'bg-white/40 hover:bg-white/50 active:bg-white/55'
-              : 'bg-black/5 hover:bg-black/10 active:bg-black/15'
+              ? 'bg-white/40 hover:bg-white/50 active:bg-white/55 border-transparent'
+              : 'bg-black/5 hover:bg-black/10 active:bg-black/15 border-transparent'
             : isDark
-              ? 'bg-white/5 border border-white/10'
-              : 'bg-white/30 border border-black/5'
+              ? 'bg-white/5 border-white/10'
+              : 'bg-white/30 border-black/5'
         } ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
         disabled={disabled}
         onClick={onClick}
@@ -405,8 +405,8 @@ export const MessageInput = ({
           className={`text-black dark:text-gray-200 ${
             uiStyle === 'neumorphic'
               ? isDark
-                ? 'bg-[rgba(30,30,50,0.8)] border-t border-white/5'
-                : 'bg-[rgba(240,237,232,0.85)] border-t border-white/60'
+                ? 'bg-[rgba(20,20,35,0.3)] border-t border-white/5'
+                : 'bg-white/10 border-t border-white/60'
               : uiStyle === 'droplet'
                 ? isDark
                   ? 'bg-[rgba(20,20,35,0.4)] border-t border-white/[0.06]'
@@ -414,8 +414,14 @@ export const MessageInput = ({
                 : 'bg-white/25 dark:bg-[rgba(20,20,35,0.45)]'
           }`}
           style={{
-            backdropFilter: 'blur(16px) saturate(1.6)',
-            WebkitBackdropFilter: 'blur(16px) saturate(1.6)',
+            backdropFilter:
+              uiStyle === 'neumorphic'
+                ? 'blur(8px) saturate(1.2)'
+                : 'blur(16px) saturate(1.6)',
+            WebkitBackdropFilter:
+              uiStyle === 'neumorphic'
+                ? 'blur(8px) saturate(1.2)'
+                : 'blur(16px) saturate(1.6)',
             boxShadow:
               uiStyle === 'neumorphic'
                 ? isDark
@@ -430,7 +436,7 @@ export const MessageInput = ({
                     : '0 -4px 24px rgba(0,0,0,0.06), inset 0 1px 0 rgba(255,255,255,0.5)',
           }}
         >
-          <div className="mx-auto max-w-4xl p-4 pb-3">
+          <div className="mx-auto max-w-4xl px-4 pt-3 pb-2">
             {/* エラーメッセージ表示 */}
             {fileError && (
               <div className="mb-2 p-2 bg-red-100 dark:bg-red-900/30 border border-red-300 dark:border-red-700 text-red-700 dark:text-red-300 rounded-lg text-sm">

--- a/src/components/mobileHeader.tsx
+++ b/src/components/mobileHeader.tsx
@@ -80,7 +80,7 @@ export const MobileHeader = ({ showLogo }: { showLogo?: boolean }) => {
             <div
               className="absolute inset-0 z-20 pointer-events-none rounded-3xl"
               style={{
-                padding: 1,
+                padding: 2,
                 WebkitMask:
                   'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
                 WebkitMaskComposite: 'xor',
@@ -89,7 +89,7 @@ export const MobileHeader = ({ showLogo }: { showLogo?: boolean }) => {
               }}
             >
               <LiquidMetal
-                colorBack="#aaaaac"
+                colorBack="#c8c8cc"
                 colorTint="#ffffff"
                 speed={0.3}
                 repetition={6}

--- a/src/components/settings/based.tsx
+++ b/src/components/settings/based.tsx
@@ -6,6 +6,7 @@ import { TextButton } from '../textButton'
 const Based = () => {
   const { t } = useTranslation()
   const colorTheme = settingsStore((s) => s.colorTheme)
+  const uiStyle = settingsStore((s) => s.uiStyle)
   const voiceEnabled = settingsStore((s) => s.voiceEnabled)
   const voiceModel = settingsStore((s) => s.voiceModel)
   const wakeWordEnabled = settingsStore((s) => s.wakeWordEnabled)
@@ -41,6 +42,26 @@ const Based = () => {
           >
             {isDark ? 'ON' : 'OFF'}
           </TextButton>
+        </div>
+      </div>
+
+      {/* UIスタイル設定 */}
+      <div className="my-6">
+        <div className="my-4 text-xl font-bold">UI Style</div>
+        <div className="my-2">
+          <select
+            value={uiStyle}
+            onChange={(e) =>
+              settingsStore.setState({
+                uiStyle: e.target.value as 'glass' | 'neumorphic' | 'droplet',
+              })
+            }
+            className="px-4 py-2 rounded-lg bg-white/50 dark:bg-white/10 border border-gray-200 dark:border-gray-600 text-gray-800 dark:text-gray-200 focus:outline-none focus:border-secondary transition-colors"
+          >
+            <option value="glass">Glass</option>
+            <option value="neumorphic">Neumorphic</option>
+            <option value="droplet">Droplet</option>
+          </select>
         </div>
       </div>
 

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -40,6 +40,7 @@ interface General {
   useVideoAsBackground: boolean
   showPresetQuestions: boolean
   colorTheme: 'tonari' | 'tonari-dark'
+  uiStyle: 'glass' | 'neumorphic' | 'droplet'
   enableAutoCapture: boolean
   voiceEnabled: boolean
   voiceModel: 'Tomoko' | 'Kazuha'
@@ -82,6 +83,7 @@ const getInitialValuesFromEnv = (): SettingsState => {
     useVideoAsBackground: config.general.useVideoAsBackground,
     showPresetQuestions: config.general.showPresetQuestions,
     colorTheme: 'tonari' as const,
+    uiStyle: 'glass' as const,
     enableAutoCapture: true,
     voiceEnabled: false,
     voiceModel: 'Tomoko',

--- a/src/features/vrmViewer/viewer.ts
+++ b/src/features/vrmViewer/viewer.ts
@@ -97,7 +97,9 @@ export class Viewer {
               this.model.vrm.scene.visible = true
               const canvas = this._renderer?.domElement
               if (canvas) {
-                const types: EntranceAnimationType[] = ['softRise', 'glitch']
+                const types: EntranceAnimationType[] = [
+                  'softRise' /*, 'glitch' */,
+                ]
                 const pick = types[Math.floor(Math.random() * types.length)]
                 this.playEntranceAnimation(canvas, pick)
               }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -420,7 +420,7 @@ function Branding() {
           }}
         >
           <LiquidMetal
-            colorBack="#aaaaac"
+            colorBack="#c8c8cc"
             colorTint="#ffffff"
             speed={0.6}
             repetition={5}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -88,6 +88,75 @@ body {
   }
 }
 
+@keyframes gold-ring-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.gold-ring-glow {
+  position: absolute;
+  inset: -4px;
+  border-radius: 12px;
+  background: #e8af48;
+  opacity: 0;
+  filter: blur(10px);
+  transition: opacity 0.3s ease;
+}
+
+.gold-ring-glow.active {
+  opacity: 0.25;
+}
+
+.gold-ring-clip {
+  position: absolute;
+  inset: -1px;
+  border-radius: 11px;
+  overflow: hidden;
+}
+
+.gold-ring-gradient {
+  position: absolute;
+  inset: -50%;
+  width: 200%;
+  height: 200%;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  background: conic-gradient(
+    from 0deg,
+    #533517 0%,
+    #c49746 12%,
+    #feeaa5 22%,
+    #ffffff 24%,
+    #ffc0cb 25.5%,
+    #feeaa5 27%,
+    #c49746 35%,
+    #533517 47%,
+    #c49746 62%,
+    #feeaa5 72%,
+    #ffffff 74%,
+    #93c5fd 75.5%,
+    #feeaa5 77%,
+    #c49746 85%,
+    #533517 100%
+  );
+  animation: gold-ring-spin 4.5s linear infinite;
+}
+
+.gold-ring-gradient.active {
+  opacity: 1;
+}
+
+.gold-ring-inner {
+  position: absolute;
+  inset: 1px;
+  border-radius: 10px;
+  z-index: 1;
+}
+
 @keyframes dialog-overlay-in {
   from { opacity: 0; }
   to { opacity: 1; }


### PR DESCRIPTION
## Summary
- UIスタイル切り替え機能: Glass / Neumorphic / Droplet の3種を設定画面のドロップダウンで選択可能に
- 送信ボタンにゴールドリング回転アニメーション追加（テキスト入力時のみアクティブ化）
- Liquid Metalボーダーをパープル調に変更（CSSフィルター: sepia + hue-rotate）、暗部をopacity調整で軽減
- Liquid Metal枠幅を2pxに統一
- Dropletスタイル時はカメラ/送信ボタンが丸ボタンに変化
- 登場アニメーションからグリッチを除外（softRiseのみ）
- ログイン画面のLiquid MetalもメニューUIと統一

## Test plan
- [ ] Glass / Neumorphic / Droplet の各スタイルでメニューコンテナ・フッターの見た目を確認
- [ ] ライトモード/ダークモードそれぞれで3スタイルの表示確認
- [ ] 送信ボタンのゴールドリングが入力時のみ表示されることを確認
- [ ] モバイル表示でのレイアウト確認
- [ ] ログイン画面のLiquid Metalロゴがパープル調になっていることを確認
- [ ] VRM登場アニメーションがsoftRiseのみになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)