### PR TITLE
feat: LLM model switching (Bedrock / OpenRouter)

### DIFF
--- a/agentcore/app.py
+++ b/agentcore/app.py
@@ -18,6 +18,7 @@ from src.agent.sub_agents import (
     twitter_agent,
 )
 from src.agent.tonari_agent import (
+    MODEL_PROVIDER_BEDROCK,
     create_mcp_client,
     create_tonari_agent,
     create_tonari_agent_pipeline,
@@ -33,16 +34,20 @@ _current_agent = None
 _current_mcp_client = None
 _current_session_id = None
 _current_actor_id = None
+_current_model_provider = None
 
 
-def _get_or_create_agent(session_id: str, actor_id: str):
-    """同じセッションならAgentを使い回し、変わったら作り直す"""
-    global _current_agent, _current_mcp_client, _current_session_id, _current_actor_id
+def _get_or_create_agent(
+    session_id: str, actor_id: str, model_provider: str = MODEL_PROVIDER_BEDROCK
+):
+    """同じセッション・同じモデルならAgentを使い回し、変わったら作り直す"""
+    global _current_agent, _current_mcp_client, _current_session_id, _current_actor_id, _current_model_provider
 
     if (
         _current_agent is not None
         and _current_session_id == session_id
         and _current_actor_id == actor_id
+        and _current_model_provider == model_provider
     ):
         return _current_agent
 
@@ -79,15 +84,19 @@ def _get_or_create_agent(session_id: str, actor_id: str):
             session_id=session_id,
             actor_id=actor_id,
             mcp_tools=main_tools,
+            model_provider=model_provider,
         )
         _current_mcp_client = mcp_client
     except Exception as e:
         logger.warning("Gateway connection failed, running without tools: %s", e, exc_info=True)
-        agent = create_tonari_agent(session_id=session_id, actor_id=actor_id)
+        agent = create_tonari_agent(
+            session_id=session_id, actor_id=actor_id, model_provider=model_provider
+        )
 
     _current_agent = agent
     _current_session_id = session_id
     _current_actor_id = actor_id
+    _current_model_provider = model_provider
     return agent
 
 
@@ -209,6 +218,11 @@ async def invoke(payload: dict):
     session_id = payload.get("session_id", "default-session")
     actor_id = payload.get("actor_id", "anonymous")
     mode = payload.get("mode") if isinstance(payload, dict) else None
+    model_provider = (
+        payload.get("model_provider", MODEL_PROVIDER_BEDROCK)
+        if isinstance(payload, dict)
+        else MODEL_PROVIDER_BEDROCK
+    )
     image_base64 = payload.get("image_base64") if isinstance(payload, dict) else None
     image_format = (
         payload.get("image_format", "jpeg") if isinstance(payload, dict) else "jpeg"
@@ -234,7 +248,7 @@ async def invoke(payload: dict):
         return
 
     # 通常モード: フルエージェント（キャッシュ付き）
-    agent = _get_or_create_agent(session_id, actor_id)
+    agent = _get_or_create_agent(session_id, actor_id, model_provider)
 
     async for chunk in _stream_response(agent, content):
         yield chunk

--- a/agentcore/pyproject.toml
+++ b/agentcore/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "strands-agents-tools>=0.2.19",
     "mcp>=1.0.0",
     "mcp-proxy-for-aws>=1.1.6",
+    "strands-agents[litellm]>=1.23.0",
 ]
 
 [dependency-groups]

--- a/agentcore/src/agent/tonari_agent.py
+++ b/agentcore/src/agent/tonari_agent.py
@@ -1,5 +1,6 @@
 """Tonari エージェント実装"""
 
+import logging
 import os
 from typing import Optional
 
@@ -17,6 +18,12 @@ from strands.models import BedrockModel, CacheConfig
 from strands.tools.mcp import MCPClient
 
 from .prompts import PIPELINE_SYSTEM_PROMPT, TONARI_SYSTEM_PROMPT
+
+logger = logging.getLogger(__name__)
+
+# モデルプロバイダー定数
+MODEL_PROVIDER_BEDROCK = "bedrock"
+MODEL_PROVIDER_OPENROUTER = "openrouter"
 
 # デフォルトのMemory ID（AgentCore CLIで作成済み）
 DEFAULT_MEMORY_ID = "tonari_memory-aky0rJC6wh"
@@ -57,6 +64,60 @@ def _create_bedrock_model(cache_tools: bool = False) -> BedrockModel:
     return BedrockModel(**kwargs)
 
 
+def _get_ssm_parameter(name: str) -> str:
+    """SSM Parameter Storeからパラメータを取得（SecureString対応）"""
+    import boto3
+
+    ssm = boto3.client("ssm", region_name=os.getenv("AWS_REGION", "ap-northeast-1"))
+    response = ssm.get_parameter(Name=name, WithDecryption=True)
+    return response["Parameter"]["Value"]
+
+
+def _create_openrouter_model():
+    """OpenRouter経由のLiteLLMModelインスタンスを作成"""
+    from strands.models.litellm import LiteLLMModel
+    import litellm
+
+    litellm.drop_params = True
+
+    model_id = os.getenv("OPENROUTER_MODEL_ID", "openrouter/x-ai/grok-4.1-fast")
+
+    # SSMパスから実行時にAPIキーを取得
+    ssm_path = os.getenv("SSM_OPENROUTER_API_KEY", "")
+    api_key = ""
+    if ssm_path:
+        try:
+            api_key = _get_ssm_parameter(ssm_path)
+        except Exception as e:
+            logger.warning("Failed to get OpenRouter API key from SSM: %s", e)
+
+    if not api_key:
+        logger.warning("OpenRouter API key not available, falling back to Bedrock")
+        return _create_bedrock_model()
+
+    return LiteLLMModel(
+        model_id=model_id,
+        params={
+            "api_key": api_key,
+            "extra_body": {"reasoning": {"enabled": False}},
+        },
+    )
+
+
+def _create_model(
+    model_provider: str = MODEL_PROVIDER_BEDROCK, cache_tools: bool = False
+):
+    """モデルプロバイダーに応じたモデルインスタンスを作成
+
+    Args:
+        model_provider: モデルプロバイダー ("bedrock" or "openrouter")
+        cache_tools: ツール定義のプロンプトキャッシングを有効にするか（Bedrockのみ）
+    """
+    if model_provider == MODEL_PROVIDER_OPENROUTER:
+        return _create_openrouter_model()
+    return _create_bedrock_model(cache_tools=cache_tools)
+
+
 def _create_memory_config(
     session_id: str,
     actor_id: str,
@@ -94,6 +155,7 @@ def create_tonari_agent(
     session_id: str = "default-session",
     actor_id: str = "anonymous",
     mcp_tools: Optional[list] = None,
+    model_provider: str = MODEL_PROVIDER_BEDROCK,
 ) -> Agent:
     """Tonariエージェントを作成（フルモード：LTM + ツール付き）
 
@@ -101,6 +163,7 @@ def create_tonari_agent(
         session_id: セッションID（タブ単位で管理）
         actor_id: ユーザーID（ブラウザ単位で永続化）
         mcp_tools: MCPから取得したツールリスト（オプション）
+        model_provider: モデルプロバイダー ("bedrock" or "openrouter")
 
     Returns:
         Agent: セッション管理機能付きのTonariエージェント
@@ -113,7 +176,7 @@ def create_tonari_agent(
 
     has_tools = bool(mcp_tools)
     agent = Agent(
-        model=_create_bedrock_model(cache_tools=has_tools),
+        model=_create_model(model_provider, cache_tools=has_tools),
         system_prompt=TONARI_SYSTEM_PROMPT,
         conversation_manager=SlidingWindowConversationManager(window_size=10),
         session_manager=session_manager,
@@ -125,6 +188,7 @@ def create_tonari_agent(
 def create_tonari_agent_light(
     session_id: str = "default-session",
     actor_id: str = "anonymous",
+    model_provider: str = MODEL_PROVIDER_BEDROCK,
 ) -> Agent:
     """Tonariエージェントを作成（軽量モード：STMのみ、ツールなし）
 
@@ -138,7 +202,7 @@ def create_tonari_agent_light(
     )
 
     agent = Agent(
-        model=_create_bedrock_model(),
+        model=_create_model(model_provider),
         system_prompt=TONARI_SYSTEM_PROMPT,
         conversation_manager=SlidingWindowConversationManager(window_size=10),
         session_manager=session_manager,

--- a/infra/lib/agentcore-construct.ts
+++ b/infra/lib/agentcore-construct.ts
@@ -1035,6 +1035,16 @@ export class AgentCoreConstruct extends Construct {
             }),
           ],
         }),
+        SsmAccess: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              actions: ['ssm:GetParameter'],
+              resources: [
+                `arn:aws:ssm:${region}:${account}:parameter/tonari/openrouter-api-key`,
+              ],
+            }),
+          ],
+        }),
         WorkloadIdentity: new iam.PolicyDocument({
           statements: [
             new iam.PolicyStatement({
@@ -1069,6 +1079,7 @@ export class AgentCoreConstruct extends Construct {
         AGENTCORE_GATEWAY_URL: gateway.gatewayUrl!,
         AWS_REGION: region,
         BEDROCK_MODEL_ID: 'jp.anthropic.claude-haiku-4-5-20251001-v1:0',
+        SSM_OPENROUTER_API_KEY: '/tonari/openrouter-api-key',
       },
     })
     this.runtimeArn = runtime.agentRuntimeArn

--- a/src/components/settings/based.tsx
+++ b/src/components/settings/based.tsx
@@ -1,12 +1,31 @@
 import { useTranslation } from 'react-i18next'
 import settingsStore from '@/features/stores/settings'
+import type { ModelProvider } from '@/features/stores/settings'
 import homeStore from '@/features/stores/home'
 import { TextButton } from '../textButton'
+
+const MODEL_OPTIONS: {
+  value: ModelProvider
+  label: string
+  description: string
+}[] = [
+  {
+    value: 'bedrock',
+    label: 'Claude Haiku 4.5',
+    description: 'Amazon Bedrock',
+  },
+  {
+    value: 'openrouter',
+    label: 'Grok 4.1 Fast',
+    description: 'OpenRouter',
+  },
+]
 
 const Based = () => {
   const { t } = useTranslation()
   const colorTheme = settingsStore((s) => s.colorTheme)
   const uiStyle = settingsStore((s) => s.uiStyle)
+  const modelProvider = settingsStore((s) => s.modelProvider)
   const voiceEnabled = settingsStore((s) => s.voiceEnabled)
   const voiceModel = settingsStore((s) => s.voiceModel)
   const wakeWordEnabled = settingsStore((s) => s.wakeWordEnabled)
@@ -26,6 +45,27 @@ const Based = () => {
             }}
           />
           <h2 className="text-2xl font-bold">{t('BasedSettings')}</h2>
+        </div>
+      </div>
+
+      {/* LLMモデル選択 */}
+      <div className="my-6">
+        <div className="my-4 text-xl font-bold">LLM Model</div>
+        <div className="my-2 flex gap-2">
+          {MODEL_OPTIONS.map((option) => (
+            <TextButton
+              key={option.value}
+              onClick={() =>
+                settingsStore.setState({ modelProvider: option.value })
+              }
+            >
+              {option.label}
+              {modelProvider === option.value ? ' ✓' : ''}
+            </TextButton>
+          ))}
+        </div>
+        <div className="mt-2 text-sm opacity-60">
+          {MODEL_OPTIONS.find((o) => o.value === modelProvider)?.description}
         </div>
       </div>
 

--- a/src/features/chat/agentCoreChat.ts
+++ b/src/features/chat/agentCoreChat.ts
@@ -1,3 +1,5 @@
+import settingsStore from '@/features/stores/settings'
+
 export type ToolEvent = { type: 'tool_start' | 'tool_end'; tool?: string }
 export type StreamChunk = string | ToolEvent
 
@@ -53,6 +55,7 @@ export async function getAgentCoreChatResponseStream(
       message: userMessage,
       sessionId: getSessionId(),
       actorId: getActorId(),
+      modelProvider: settingsStore.getState().modelProvider,
       ...(imageBase64 && {
         imageBase64,
         imageFormat: 'jpeg',

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -28,8 +28,11 @@ interface Character {
   lightingIntensity: number
 }
 
+export type ModelProvider = 'bedrock' | 'openrouter'
+
 interface General {
   selectAIService: AIService
+  modelProvider: ModelProvider
   selectLanguage: Language
   includeTimestampInUserMessage: boolean
   showControlPanel: boolean
@@ -73,6 +76,7 @@ const getInitialValuesFromEnv = (): SettingsState => {
 
     // General (from config)
     selectAIService: config.ai.service as AIService,
+    modelProvider: 'bedrock' as ModelProvider,
     selectLanguage: config.general.language as Language,
     includeTimestampInUserMessage: config.general.includeTimestampInUserMessage,
     showControlPanel: config.general.showControlPanel,
@@ -136,6 +140,7 @@ const settingsStore = create<SettingsState>()(
       characterRotation: state.characterRotation,
       lightingIntensity: state.lightingIntensity,
       selectAIService: state.selectAIService,
+      modelProvider: state.modelProvider,
       selectLanguage: state.selectLanguage,
       includeTimestampInUserMessage: state.includeTimestampInUserMessage,
       showControlPanel: state.showControlPanel,

--- a/src/pages/api/ai/agentcore.ts
+++ b/src/pages/api/ai/agentcore.ts
@@ -79,7 +79,14 @@ export default async function handler(
   }
 
   try {
-    const { message, sessionId, actorId, imageBase64, imageFormat } = req.body
+    const {
+      message,
+      sessionId,
+      actorId,
+      modelProvider,
+      imageBase64,
+      imageFormat,
+    } = req.body
 
     if (!message && !imageBase64) {
       return res.status(400).json({ error: 'Message or image is required' })
@@ -122,6 +129,7 @@ export default async function handler(
         prompt: promptWithTimestamp,
         session_id: sessionId, // AgentCore Memory STM用（セッション単位）
         actor_id: actorId, // AgentCore Memory LTM用（ユーザー単位）
+        ...(modelProvider && { model_provider: modelProvider }),
         ...(imageBase64 && {
           image_base64: imageBase64,
           image_format: imageFormat || 'jpeg',


### PR DESCRIPTION
## 概要
設定画面からLLMモデルを切り替えられる機能を追加。Bedrock Claude Haiku 4.5とOpenRouter Grok 4.1 Fastを選択可能にする。

## 変更点
### フロントエンド
- 設定画面（Based Settings）にLLMモデル切替ボタンを追加
- `ModelProvider`型（`bedrock` / `openrouter`）をZustandストアに追加（localStorage永続化）
- APIリクエストに`modelProvider`パラメータを含めるよう変更
- BFF（API Route）で`model_provider`をAgentCore Runtimeに転送

### バックエンド（AgentCore）
- `LiteLLMModel`によるOpenRouter Grok 4.1 Fast対応を追加
- SSM Parameter Storeからランタイムで`OPENROUTER_API_KEY`を取得（SecureString）
- `model_provider`パラメータに応じてモデルを動的に切り替え
- モデルプロバイダー変更時にエージェントを再作成

### インフラ（CDK）
- AgentCore RuntimeのIAMロールに`ssm:GetParameter`権限を追加
- 環境変数`SSM_OPENROUTER_API_KEY`にSSMパスを設定
- `pyproject.toml`に`strands-agents[litellm]`依存を追加