### PR TITLE
Switch to OpenAIModel for OpenRouter and add reasoning toggle

### DIFF
--- a/agentcore/app.py
+++ b/agentcore/app.py
@@ -36,19 +36,22 @@ _current_mcp_client = None
 _current_session_id = None
 _current_actor_id = None
 _current_model_provider = None
+_current_reasoning_enabled = None
 
 
 def _get_or_create_agent(
-    session_id: str, actor_id: str, model_provider: str = MODEL_PROVIDER_BEDROCK
+    session_id: str, actor_id: str, model_provider: str = MODEL_PROVIDER_BEDROCK,
+    reasoning_enabled: bool = False,
 ):
     """同じセッション・同じモデルならAgentを使い回し、変わったら作り直す"""
-    global _current_agent, _current_mcp_client, _current_session_id, _current_actor_id, _current_model_provider
+    global _current_agent, _current_mcp_client, _current_session_id, _current_actor_id, _current_model_provider, _current_reasoning_enabled
 
     if (
         _current_agent is not None
         and _current_session_id == session_id
         and _current_actor_id == actor_id
         and _current_model_provider == model_provider
+        and _current_reasoning_enabled == reasoning_enabled
     ):
         return _current_agent
 
@@ -86,18 +89,21 @@ def _get_or_create_agent(
             actor_id=actor_id,
             mcp_tools=main_tools,
             model_provider=model_provider,
+            reasoning_enabled=reasoning_enabled,
         )
         _current_mcp_client = mcp_client
     except Exception as e:
         logger.warning("Gateway connection failed, running without tools: %s", e, exc_info=True)
         agent = create_tonari_agent(
-            session_id=session_id, actor_id=actor_id, model_provider=model_provider
+            session_id=session_id, actor_id=actor_id, model_provider=model_provider,
+            reasoning_enabled=reasoning_enabled,
         )
 
     _current_agent = agent
     _current_session_id = session_id
     _current_actor_id = actor_id
     _current_model_provider = model_provider
+    _current_reasoning_enabled = reasoning_enabled
     return agent
 
 
@@ -225,6 +231,12 @@ async def invoke(payload: dict):
         if isinstance(payload, dict)
         else default_provider
     )
+    reasoning_enabled = (
+        payload.get("reasoning_enabled", False)
+        if isinstance(payload, dict)
+        else False
+    )
+    logger.info("invoke: model_provider=%s, reasoning_enabled=%s", model_provider, reasoning_enabled)
     image_base64 = payload.get("image_base64") if isinstance(payload, dict) else None
     image_format = (
         payload.get("image_format", "jpeg") if isinstance(payload, dict) else "jpeg"
@@ -250,7 +262,7 @@ async def invoke(payload: dict):
         return
 
     # 通常モード: フルエージェント（キャッシュ付き）
-    agent = _get_or_create_agent(session_id, actor_id, model_provider)
+    agent = _get_or_create_agent(session_id, actor_id, model_provider, reasoning_enabled)
 
     async for chunk in _stream_response(agent, content):
         yield chunk

--- a/agentcore/pyproject.toml
+++ b/agentcore/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "strands-agents-tools>=0.2.19",
     "mcp>=1.0.0",
     "mcp-proxy-for-aws>=1.1.6",
-    "strands-agents[litellm]>=1.23.0",
+    "openai>=1.0.0",
 ]
 
 [dependency-groups]

--- a/agentcore/src/agent/tonari_agent.py
+++ b/agentcore/src/agent/tonari_agent.py
@@ -73,14 +73,15 @@ def _get_ssm_parameter(name: str) -> str:
     return response["Parameter"]["Value"]
 
 
-def _create_openrouter_model():
-    """OpenRouter経由のLiteLLMModelインスタンスを作成"""
-    from strands.models.litellm import LiteLLMModel
-    import litellm
+def _create_openrouter_model(reasoning_enabled: bool = False):
+    """OpenRouter経由のOpenAIModelインスタンスを作成
 
-    litellm.drop_params = True
+    Args:
+        reasoning_enabled: reasoningを有効にするか（Trueで精度向上、応答遅延）
+    """
+    from strands.models.openai import OpenAIModel
 
-    model_id = os.getenv("OPENROUTER_MODEL_ID", "openrouter/x-ai/grok-4.1-fast")
+    model_id = os.getenv("OPENROUTER_MODEL_ID", "x-ai/grok-4.1-fast")
 
     # SSMパスから実行時にAPIキーを取得
     ssm_path = os.getenv("SSM_OPENROUTER_API_KEY", "")
@@ -95,12 +96,16 @@ def _create_openrouter_model():
         logger.warning("OpenRouter API key not available, falling back to Bedrock")
         return _create_bedrock_model()
 
-    return LiteLLMModel(
-        model_id=model_id,
-        params={
+    params = {}
+    if not reasoning_enabled:
+        params["extra_body"] = {"reasoning": {"enabled": False}}
+    return OpenAIModel(
+        client_args={
             "api_key": api_key,
-            "extra_body": {"reasoning": {"enabled": False}},
+            "base_url": "https://openrouter.ai/api/v1",
         },
+        model_id=model_id,
+        params=params,
     )
 
 
@@ -110,17 +115,19 @@ def _get_default_model_provider() -> str:
 
 
 def _create_model(
-    model_provider: str | None = None, cache_tools: bool = False
+    model_provider: str | None = None, cache_tools: bool = False,
+    reasoning_enabled: bool = False,
 ):
     """モデルプロバイダーに応じたモデルインスタンスを作成
 
     Args:
         model_provider: モデルプロバイダー ("bedrock" or "openrouter")。Noneの場合は環境変数を参照
         cache_tools: ツール定義のプロンプトキャッシングを有効にするか（Bedrockのみ）
+        reasoning_enabled: reasoningを有効にするか（OpenRouterのみ）
     """
     provider = model_provider or _get_default_model_provider()
     if provider == MODEL_PROVIDER_OPENROUTER:
-        return _create_openrouter_model()
+        return _create_openrouter_model(reasoning_enabled=reasoning_enabled)
     return _create_bedrock_model(cache_tools=cache_tools)
 
 
@@ -162,6 +169,7 @@ def create_tonari_agent(
     actor_id: str = "anonymous",
     mcp_tools: Optional[list] = None,
     model_provider: str = MODEL_PROVIDER_BEDROCK,
+    reasoning_enabled: bool = False,
 ) -> Agent:
     """Tonariエージェントを作成（フルモード：LTM + ツール付き）
 
@@ -170,6 +178,7 @@ def create_tonari_agent(
         actor_id: ユーザーID（ブラウザ単位で永続化）
         mcp_tools: MCPから取得したツールリスト（オプション）
         model_provider: モデルプロバイダー ("bedrock" or "openrouter")
+        reasoning_enabled: reasoningを有効にするか（OpenRouterのみ）
 
     Returns:
         Agent: セッション管理機能付きのTonariエージェント
@@ -182,7 +191,7 @@ def create_tonari_agent(
 
     has_tools = bool(mcp_tools)
     agent = Agent(
-        model=_create_model(model_provider, cache_tools=has_tools),
+        model=_create_model(model_provider, cache_tools=has_tools, reasoning_enabled=reasoning_enabled),
         system_prompt=TONARI_SYSTEM_PROMPT,
         conversation_manager=SlidingWindowConversationManager(window_size=10),
         session_manager=session_manager,

--- a/src/components/settings/based.tsx
+++ b/src/components/settings/based.tsx
@@ -26,6 +26,7 @@ const Based = () => {
   const colorTheme = settingsStore((s) => s.colorTheme)
   const uiStyle = settingsStore((s) => s.uiStyle)
   const modelProvider = settingsStore((s) => s.modelProvider)
+  const reasoningEnabled = settingsStore((s) => s.reasoningEnabled)
   const voiceEnabled = settingsStore((s) => s.voiceEnabled)
   const voiceModel = settingsStore((s) => s.voiceModel)
   const wakeWordEnabled = settingsStore((s) => s.wakeWordEnabled)
@@ -68,6 +69,29 @@ const Based = () => {
           {MODEL_OPTIONS.find((o) => o.value === modelProvider)?.description}
         </div>
       </div>
+
+      {/* Reasoning設定（OpenRouterのみ） */}
+      {modelProvider === 'openrouter' && (
+        <div className="my-6">
+          <div className="my-4 text-xl font-bold">Reasoning</div>
+          <div className="my-2 flex gap-2">
+            <TextButton
+              onClick={() =>
+                settingsStore.setState({
+                  reasoningEnabled: !reasoningEnabled,
+                })
+              }
+            >
+              {reasoningEnabled ? 'ON ✓' : 'OFF ✓'}
+            </TextButton>
+          </div>
+          <div className="mt-2 text-sm opacity-60">
+            {reasoningEnabled
+              ? 'Reasoning ON: 推論精度が向上しますが、応答が遅くなります'
+              : 'Reasoning OFF: 高速応答（推奨）'}
+          </div>
+        </div>
+      )}
 
       {/* ダークモード設定 */}
       <div className="my-6">

--- a/src/features/chat/agentCoreChat.ts
+++ b/src/features/chat/agentCoreChat.ts
@@ -56,6 +56,7 @@ export async function getAgentCoreChatResponseStream(
       sessionId: getSessionId(),
       actorId: getActorId(),
       modelProvider: settingsStore.getState().modelProvider,
+      reasoningEnabled: settingsStore.getState().reasoningEnabled,
       ...(imageBase64 && {
         imageBase64,
         imageFormat: 'jpeg',

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -48,6 +48,7 @@ interface General {
   voiceEnabled: boolean
   voiceModel: 'Tomoko' | 'Kazuha'
   wakeWordEnabled: boolean
+  reasoningEnabled: boolean
 }
 
 export type SettingsState = Character & General
@@ -92,6 +93,7 @@ const getInitialValuesFromEnv = (): SettingsState => {
     voiceEnabled: false,
     voiceModel: 'Tomoko',
     wakeWordEnabled: false,
+    reasoningEnabled: false,
   }
 }
 
@@ -155,6 +157,7 @@ const settingsStore = create<SettingsState>()(
       voiceEnabled: state.voiceEnabled,
       voiceModel: state.voiceModel,
       wakeWordEnabled: state.wakeWordEnabled,
+      reasoningEnabled: state.reasoningEnabled,
     }),
   })
 )

--- a/src/pages/api/ai/agentcore.ts
+++ b/src/pages/api/ai/agentcore.ts
@@ -84,6 +84,7 @@ export default async function handler(
       sessionId,
       actorId,
       modelProvider,
+      reasoningEnabled,
       imageBase64,
       imageFormat,
     } = req.body
@@ -130,6 +131,9 @@ export default async function handler(
         session_id: sessionId, // AgentCore Memory STM用（セッション単位）
         actor_id: actorId, // AgentCore Memory LTM用（ユーザー単位）
         ...(modelProvider && { model_provider: modelProvider }),
+        ...(reasoningEnabled !== undefined && {
+          reasoning_enabled: reasoningEnabled,
+        }),
         ...(imageBase64 && {
           image_base64: imageBase64,
           image_format: imageFormat || 'jpeg',


### PR DESCRIPTION
## 概要
LLMプロバイダーの切替をLiteLLM経由からOpenAIModel直接接続に変更し、reasoning ON/OFFの設定UIを追加。

## 変更点
- OpenRouter接続をLiteLLMModel → OpenAIModelに切替（litellm依存を削除、openai依存を追加）
- フロントエンドにreasoning ON/OFF トグルを追加（OpenRouter選択時のみ表示）
- reasoning設定をフロントからバックエンドまで貫通（settings store → API Route → AgentCore Runtime）
- エージェントキャッシュのキーにreasoning設定を含め、切替時にエージェントを再作成
- 環境変数MODEL_PROVIDERで全エージェント（メイン・サブ・パイプライン）のモデルを一括切替
- サブエージェントを統一モデルファクトリ(_create_model)に移行
- システムプロンプトにオーナー呼称を必須化
- CDKにSSMパラメータアクセス権限とMODEL_PROVIDER環境変数を追加