### PR TITLE
feat: Code Interpreter integration with AWS cost visualization

### DIFF
--- a/agentcore/app.py
+++ b/agentcore/app.py
@@ -7,6 +7,8 @@ import os
 
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 
+from strands import AgentSkills
+
 from src.agent.sub_agents import (
     briefing_agent,
     calendar_agent,
@@ -21,6 +23,8 @@ from src.agent.sub_agents import (
 )
 from strands_tools.tavily import tavily_search
 from src.agent.twitter_tools import TWITTER_TOOLS
+from src.agent.aws_cost import get_aws_cost
+from src.agent.code_interpreter import drain_pending_images, execute_python
 from src.agent.tonari_agent import (
     MODEL_PROVIDER_BEDROCK,
     _get_default_model_provider,
@@ -63,6 +67,16 @@ def _init_tavily_api_key():
 _init_tavily_api_key()
 
 app = BedrockAgentCoreApp()
+
+# Skills プラグインの初期化
+SKILLS_DIR = os.path.join(os.path.dirname(__file__), "skills")
+_skills_plugin = None
+if os.path.isdir(SKILLS_DIR):
+    try:
+        _skills_plugin = AgentSkills(skills=SKILLS_DIR)
+        logger.info("AgentSkills loaded from %s", SKILLS_DIR)
+    except Exception as e:
+        logger.warning("Failed to load AgentSkills: %s", e)
 
 # 保持中のAgentとそのセッション情報
 _current_agent = None
@@ -116,14 +130,18 @@ def _get_or_create_agent(
         main_tools = tool_map["main"] + [
             task_agent, calendar_agent, gmail_agent, notion_agent,
             briefing_agent, diary_agent, intro_agent, twitter_agent,
+            execute_python,
+            get_aws_cost,
         ]
 
+        plugins = [_skills_plugin] if _skills_plugin else []
         agent = create_tonari_agent(
             session_id=session_id,
             actor_id=actor_id,
             mcp_tools=main_tools,
             model_provider=model_provider,
             reasoning_enabled=reasoning_enabled,
+            plugins=plugins,
         )
         _current_mcp_client = mcp_client
     except Exception as e:
@@ -236,8 +254,21 @@ async def _stream_response(agent, content):
     Yields:
         str: テキストチャンク
         dict: ツールイベント ({"type": "tool_start", "tool": name} or {"type": "tool_end"})
+        dict: 画像イベント ({"type": "image", "base64": ..., "format": "png"})
     """
     event_queue = asyncio.Queue()
+
+    async def _emit_pending_images():
+        """保留画像URLをキューに送出"""
+        images = drain_pending_images()
+        for img in images:
+            url = img.get("url", "")
+            if url:
+                logger.info("Emitting image URL: %s...", url[:80])
+                await event_queue.put({
+                    "type": "image",
+                    "url": url,
+                })
 
     async def _run_agent():
         active_tool = None
@@ -249,6 +280,7 @@ async def _stream_response(agent, content):
                         if isinstance(text, str):
                             if active_tool is not None:
                                 await event_queue.put({"type": "tool_end"})
+                                await _emit_pending_images()
                                 active_tool = None
                             await event_queue.put(text)
                     elif "current_tool_use" in event:
@@ -257,10 +289,12 @@ async def _stream_response(agent, content):
                         if tool_name != active_tool:
                             if active_tool is not None:
                                 await event_queue.put({"type": "tool_end"})
+                                await _emit_pending_images()
                             active_tool = tool_name
                             await event_queue.put({"type": "tool_start", "tool": tool_name})
             if active_tool is not None:
                 await event_queue.put({"type": "tool_end"})
+                await _emit_pending_images()
         except Exception as e:
             logger.error("Agent stream error: %s", e, exc_info=True)
             await event_queue.put({"type": "error", "message": str(e)})

--- a/agentcore/skills/aws-cost/SKILL.md
+++ b/agentcore/skills/aws-cost/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: aws-cost
+description: Analyze and visualize AWS cost data using get_aws_cost for data retrieval and execute_python for matplotlib chart generation
+allowed-tools: get_aws_cost execute_python
+---
+
+# AWS Cost Analysis Skill
+
+Two-step process: fetch data with `get_aws_cost`, then visualize with `execute_python`.
+
+## Critical Rules
+
+- **NEVER use boto3 inside execute_python** — the sandbox has no AWS credentials.
+- **NEVER call plt.savefig()** — images are auto-captured from open figures.
+- **NEVER call plt.close()** — closing figures prevents image capture.
+- **Use English for ALL text** in charts (titles, labels, legends) — Japanese fonts are unavailable.
+- Just create figures with `plt.subplots()` and leave them open.
+
+## Step 1: Fetch Data
+
+```
+get_aws_cost(period="monthly", months=3, group_by_service=True)
+```
+
+## Step 2: Visualize
+
+Pass the cost data as a Python literal. Example:
+
+```python
+import matplotlib.pyplot as plt
+
+data = ...  # paste get_aws_cost result here
+
+months = [d["start"][:7] for d in data]
+totals = [d["total"] for d in data]
+
+fig, ax = plt.subplots(figsize=(10, 5))
+bars = ax.bar(months, totals, color='#4A90D9')
+ax.set_title('Monthly AWS Cost', fontsize=14, fontweight='bold')
+ax.set_ylabel('Cost (USD)')
+for bar, cost in zip(bars, totals):
+    ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 0.5,
+            f'${cost:.2f}', ha='center', va='bottom', fontsize=9)
+plt.tight_layout()
+# DO NOT call plt.savefig() or plt.close() — images are auto-captured
+```
+
+### Service Breakdown
+
+```python
+import matplotlib.pyplot as plt
+
+all_services = {}
+for d in data:
+    for svc, cost in d.get("services", {}).items():
+        all_services[svc] = all_services.get(svc, 0) + cost
+
+sorted_svcs = sorted(all_services.items(), key=lambda x: x[1], reverse=True)[:10]
+services = [s[0] for s in sorted_svcs]
+costs = [s[1] for s in sorted_svcs]
+
+fig, ax = plt.subplots(figsize=(10, 6))
+ax.barh(range(len(services)), costs, color='#4A90D9')
+ax.set_yticks(range(len(services)))
+ax.set_yticklabels(services, fontsize=8)
+ax.set_xlabel('Cost (USD)')
+ax.set_title('AWS Cost by Service', fontsize=14, fontweight='bold')
+ax.invert_yaxis()
+for i, cost in enumerate(costs):
+    ax.text(cost + 0.1, i, f'${cost:.2f}', va='center', fontsize=9)
+plt.tight_layout()
+# DO NOT call plt.savefig() or plt.close()
+```

--- a/agentcore/src/agent/aws_cost.py
+++ b/agentcore/src/agent/aws_cost.py
@@ -1,0 +1,97 @@
+"""AWS Cost Explorer tool for Strands Agent.
+
+Runtime 側で IAM 権限を使ってコストデータを取得する。
+取得したデータは execute_python (Code Interpreter) でグラフ化できる。
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta
+
+import boto3
+from strands import tool
+
+logger = logging.getLogger(__name__)
+
+# モジュールロード時に CE クライアントを即時初期化（STS クレデンシャル取得を前倒し）
+_ce_client = boto3.client(
+    "ce", region_name=os.getenv("AWS_REGION", "ap-northeast-1")
+)
+logger.info("Cost Explorer client initialized")
+
+
+@tool
+def get_aws_cost(
+    period: str = "monthly",
+    months: int = 1,
+    group_by_service: bool = True,
+) -> str:
+    """Retrieve AWS cost data from Cost Explorer.
+
+    Use this tool to fetch cost data. Then pass the result to execute_python
+    to create matplotlib charts for visualization.
+
+    Args:
+        period: Granularity - "monthly" or "daily".
+        months: Number of months to look back (default: 1, max: 6).
+        group_by_service: If True, break down costs by AWS service.
+
+    Returns:
+        JSON string with cost data.
+    """
+    ce = _ce_client
+
+    now = datetime.utcnow()
+    end = now.strftime("%Y-%m-%d")
+    months = min(max(months, 1), 6)
+    start = (now - timedelta(days=30 * months)).replace(day=1).strftime("%Y-%m-%d")
+
+    granularity = "MONTHLY" if period == "monthly" else "DAILY"
+
+    try:
+        kwargs = {
+            "TimePeriod": {"Start": start, "End": end},
+            "Granularity": granularity,
+            "Metrics": ["UnblendedCost"],
+        }
+        if group_by_service:
+            kwargs["GroupBy"] = [{"Type": "DIMENSION", "Key": "SERVICE"}]
+
+        response = ce.get_cost_and_usage(**kwargs)
+        results = response.get("ResultsByTime", [])
+
+        if group_by_service:
+            data = []
+            for r in results:
+                services = {}
+                for group in r.get("Groups", []):
+                    amount = float(group["Metrics"]["UnblendedCost"]["Amount"])
+                    if amount > 0.01:
+                        services[group["Keys"][0]] = round(amount, 2)
+                data.append({
+                    "start": r["TimePeriod"]["Start"],
+                    "end": r["TimePeriod"]["End"],
+                    "total": round(sum(services.values()), 2),
+                    "services": services,
+                })
+        else:
+            data = [
+                {
+                    "start": r["TimePeriod"]["Start"],
+                    "end": r["TimePeriod"]["End"],
+                    "total": round(float(r["Total"]["UnblendedCost"]["Amount"]), 2),
+                }
+                for r in results
+            ]
+
+        return json.dumps({
+            "granularity": granularity,
+            "start": start,
+            "end": end,
+            "data": data,
+        }, ensure_ascii=False)
+
+    except Exception as e:
+        logger.error("Cost Explorer error: %s", e, exc_info=True)
+        return json.dumps({"error": str(e)})

--- a/agentcore/src/agent/code_interpreter.py
+++ b/agentcore/src/agent/code_interpreter.py
@@ -1,0 +1,178 @@
+"""Code Interpreter tool for Strands Agent.
+
+AgentCore Code Interpreter sandbox を使って Python コードを実行し、
+matplotlib で生成されたグラフを S3 にアップロードして署名付き URL を返す。
+"""
+
+import base64
+import json
+import logging
+import os
+import threading
+import uuid
+from datetime import datetime
+
+import boto3
+from strands import tool
+
+logger = logging.getLogger(__name__)
+
+CODE_INTERPRETER_REGION = os.getenv("CODE_INTERPRETER_REGION", "us-west-2")
+OUTPUT_BUCKET = os.getenv("CODE_INTERPRETER_OUTPUT_BUCKET", "")
+AWS_REGION = os.getenv("AWS_REGION", "ap-northeast-1")
+
+# モジュールロード時に S3 クライアントを即時初期化
+_s3_client = boto3.client("s3", region_name=AWS_REGION)
+
+
+# ツール実行後に画像 URL を SSE ストリームへ送出するためのキュー
+_pending_images: list[dict] = []
+_pending_images_lock = threading.Lock()
+
+
+def drain_pending_images() -> list[dict]:
+    """保留中の画像URLをすべて取り出して返す"""
+    with _pending_images_lock:
+        images = list(_pending_images)
+        _pending_images.clear()
+    return images
+
+
+def _upload_to_s3(img_bytes: bytes, figure_num: int) -> str | None:
+    """画像を S3 にアップロードして署名付き URL を返す"""
+    if not OUTPUT_BUCKET:
+        logger.warning("CODE_INTERPRETER_OUTPUT_BUCKET not set, skipping S3 upload")
+        return None
+
+    try:
+        s3 = _s3_client
+        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        key = f"outputs/{timestamp}_{uuid.uuid4().hex[:8]}_fig{figure_num}.png"
+
+        s3.put_object(
+            Bucket=OUTPUT_BUCKET,
+            Key=key,
+            Body=img_bytes,
+            ContentType="image/png",
+        )
+
+        url = s3.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": OUTPUT_BUCKET, "Key": key},
+            ExpiresIn=3600,
+        )
+        logger.info("Uploaded image to s3://%s/%s (%.1f KB)", OUTPUT_BUCKET, key, len(img_bytes) / 1024)
+        return url
+    except Exception as e:
+        logger.error("S3 upload failed: %s", e, exc_info=True)
+        return None
+
+
+@tool
+def execute_python(code: str, description: str = "") -> str:
+    """Execute Python code in a sandboxed environment. Use this to run data analysis,
+    generate charts with matplotlib, or perform calculations.
+
+    Available libraries: pandas, numpy, matplotlib, json, datetime.
+    Use ONLY matplotlib for plotting (not seaborn).
+    Use English for all chart labels and titles (Japanese fonts are not available).
+
+    IMPORTANT for chart generation:
+    - Do NOT call plt.savefig() — images are auto-captured from open figures.
+    - Do NOT call plt.close() — closing figures prevents image capture.
+    - Just create figures with plt.subplots() and leave them open.
+    - Do NOT use boto3 — the sandbox has no AWS credentials.
+
+    Args:
+        code: Python code to execute.
+        description: Optional description of what the code does.
+
+    Returns:
+        JSON string with execution results including stdout, stderr, and image URLs.
+    """
+    from bedrock_agentcore.tools.code_interpreter_client import code_session
+
+    if description:
+        code = f"# {description}\n{code}"
+
+    # matplotlib の画像キャプチャコードを注入
+    img_code = f"""
+import matplotlib
+matplotlib.use('Agg')
+{code}
+import matplotlib.pyplot as plt, base64, io, json as _json
+_imgs = []
+for _i in plt.get_fignums():
+    _b = io.BytesIO()
+    plt.figure(_i).savefig(_b, format='png', bbox_inches='tight', dpi=100)
+    _b.seek(0)
+    _imgs.append({{'i': _i, 'd': base64.b64encode(_b.read()).decode()}})
+if _imgs:
+    print('_IMG_' + _json.dumps(_imgs) + '_END_')
+plt.close('all')
+"""
+
+    try:
+        with code_session(CODE_INTERPRETER_REGION) as code_client:
+            response = code_client.invoke(
+                "executeCode",
+                {
+                    "code": img_code,
+                    "language": "python",
+                    "clearContext": False,
+                },
+            )
+            result = None
+            for event in response["stream"]:
+                result = event["result"]
+
+            if result is None:
+                return json.dumps({
+                    "isError": True,
+                    "stdout": "",
+                    "stderr": "No result from Code Interpreter",
+                })
+
+        stdout = result.get("structuredContent", {}).get("stdout", "")
+        stderr = result.get("structuredContent", {}).get("stderr", "")
+        is_error = result.get("isError", False)
+
+        # base64 画像の抽出 → S3 アップロード → 署名付き URL をキューに追加
+        image_urls = []
+        clean_stdout = stdout
+        if "_IMG_" in stdout and "_END_" in stdout:
+            try:
+                start = stdout.find("_IMG_") + 5
+                end = stdout.find("_END_")
+                img_json = stdout[start:end]
+                imgs = json.loads(img_json)
+                for img in imgs:
+                    img_bytes = base64.b64decode(img["d"])
+                    url = _upload_to_s3(img_bytes, img["i"])
+                    if url:
+                        image_urls.append(url)
+                        with _pending_images_lock:
+                            _pending_images.append({"url": url})
+                clean_stdout = stdout[:stdout.find("_IMG_")].strip()
+                logger.info("Code Interpreter generated %d image(s), uploaded %d to S3",
+                            len(imgs), len(image_urls))
+            except Exception as e:
+                logger.warning("Failed to parse/upload image data: %s", e)
+
+        result = {
+            "isError": is_error,
+            "stdout": clean_stdout,
+            "stderr": stderr,
+        }
+        if image_urls:
+            result["image_urls"] = image_urls
+            result["note"] = "Images are automatically displayed to the user in the chat. Do NOT say images cannot be shown."
+        return json.dumps(result, ensure_ascii=False)
+
+    except Exception as e:
+        logger.error("Code Interpreter error: %s", e, exc_info=True)
+        return json.dumps({
+            "isError": True,
+            "stdout": "",
+            "stderr": f"Code Interpreter error: {e}",
+        })

--- a/agentcore/src/agent/tonari_agent.py
+++ b/agentcore/src/agent/tonari_agent.py
@@ -170,6 +170,7 @@ def create_tonari_agent(
     mcp_tools: Optional[list] = None,
     model_provider: str = MODEL_PROVIDER_BEDROCK,
     reasoning_enabled: bool = False,
+    plugins: Optional[list] = None,
 ) -> Agent:
     """Tonariエージェントを作成（フルモード：LTM + ツール付き）
 
@@ -179,6 +180,7 @@ def create_tonari_agent(
         mcp_tools: MCPから取得したツールリスト（オプション）
         model_provider: モデルプロバイダー ("bedrock" or "openrouter")
         reasoning_enabled: reasoningを有効にするか（OpenRouterのみ）
+        plugins: Strands Agent プラグインリスト（AgentSkills等）
 
     Returns:
         Agent: セッション管理機能付きのTonariエージェント
@@ -190,13 +192,16 @@ def create_tonari_agent(
     )
 
     has_tools = bool(mcp_tools)
-    agent = Agent(
-        model=_create_model(model_provider, cache_tools=has_tools, reasoning_enabled=reasoning_enabled),
-        system_prompt=TONARI_SYSTEM_PROMPT,
-        conversation_manager=SlidingWindowConversationManager(window_size=10),
-        session_manager=session_manager,
-        tools=mcp_tools or [],
-    )
+    kwargs = {
+        "model": _create_model(model_provider, cache_tools=has_tools, reasoning_enabled=reasoning_enabled),
+        "system_prompt": TONARI_SYSTEM_PROMPT,
+        "conversation_manager": SlidingWindowConversationManager(window_size=10),
+        "session_manager": session_manager,
+        "tools": mcp_tools or [],
+    }
+    if plugins:
+        kwargs["plugins"] = plugins
+    agent = Agent(**kwargs)
     return agent
 
 

--- a/infra/lib/agentcore-construct.ts
+++ b/infra/lib/agentcore-construct.ts
@@ -5,6 +5,7 @@ import { Platform } from 'aws-cdk-lib/aws-ecr-assets'
 import * as iam from 'aws-cdk-lib/aws-iam'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
 import * as logs from 'aws-cdk-lib/aws-logs'
+import * as s3 from 'aws-cdk-lib/aws-s3'
 import { Construct } from 'constructs'
 import * as path from 'path'
 
@@ -409,6 +410,17 @@ export class AgentCoreConstruct extends Construct {
       ]),
     })
 
+    // ========== Code Interpreter Output Bucket ==========
+    const codeInterpreterBucket = new s3.Bucket(this, 'CodeInterpreterOutputBucket', {
+      bucketName: `tonari-codeinterpreter-outputs-${account}`,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      lifecycleRules: [
+        { expiration: cdk.Duration.days(1) },
+      ],
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+    })
+
     // ========== Runtime (L2) ==========
     const artifact = agentcore.AgentRuntimeArtifact.fromAsset(
       path.join(__dirname, '../../agentcore'),
@@ -480,6 +492,34 @@ export class AgentCoreConstruct extends Construct {
                   'cloudwatch:namespace': 'bedrock-agentcore',
                 },
               },
+            }),
+          ],
+        }),
+        CodeInterpreterAccess: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              actions: [
+                'bedrock-agentcore:CreateCodeInterpreter',
+                'bedrock-agentcore:StartCodeInterpreterSession',
+                'bedrock-agentcore:InvokeCodeInterpreter',
+                'bedrock-agentcore:StopCodeInterpreterSession',
+                'bedrock-agentcore:DeleteCodeInterpreter',
+                'bedrock-agentcore:ListCodeInterpreters',
+                'bedrock-agentcore:GetCodeInterpreter',
+              ],
+              resources: ['*'],
+            }),
+          ],
+        }),
+        CostExplorerAccess: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              actions: [
+                'ce:GetCostAndUsage',
+                'ce:GetCostForecast',
+                'ce:GetDimensionValues',
+              ],
+              resources: ['*'],
             }),
           ],
         }),
@@ -557,9 +597,11 @@ export class AgentCoreConstruct extends Construct {
         ...(props.ownerTwitterUserId && {
           OWNER_TWITTER_USER_ID: props.ownerTwitterUserId,
         }),
+        CODE_INTERPRETER_OUTPUT_BUCKET: codeInterpreterBucket.bucketName,
       },
     })
     this.runtimeArn = runtime.agentRuntimeArn
+    codeInterpreterBucket.grantReadWrite(runtimeRole)
 
     // Preserve CloudFormation logical ID from L1 migration to avoid resource recreation
     const cfnRuntime = runtime.node.defaultChild as bedrockagentcore.CfnRuntime

--- a/src/components/chatLog.tsx
+++ b/src/components/chatLog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import homeStore from '@/features/stores/home'
 import settingsStore from '@/features/stores/settings'
@@ -59,24 +59,40 @@ export const ChatLog = ({ isPortrait }: { isPortrait?: boolean }) => {
                 characterName={characterName}
                 isPortrait
               />
-            ) : (
+            ) : Array.isArray(msg.content) ? (
               <>
-                {msg.content?.[0]?.text ? (
-                  <Chat
-                    role={msg.role}
-                    message={msg.content[0].text}
-                    characterName={characterName}
-                    isPortrait
-                  />
-                ) : null}
-                <ChatImage
-                  role={msg.role}
-                  imageUrl={msg.content ? msg.content[1].image : ''}
-                  characterName={characterName}
-                  isPortrait
-                />
+                {msg.content.map((block, j) => {
+                  if (block.type === 'text' && block.text) {
+                    return (
+                      <Chat
+                        key={j}
+                        role={msg.role}
+                        message={block.text}
+                        characterName={characterName}
+                        isPortrait
+                      />
+                    )
+                  }
+                  if (block.type === 'image' && block.image) {
+                    const src =
+                      block.image.startsWith('data:') ||
+                      block.image.startsWith('http')
+                        ? block.image
+                        : `data:image/png;base64,${block.image}`
+                    return (
+                      <ChatImage
+                        key={j}
+                        role={msg.role}
+                        imageUrl={src}
+                        characterName={characterName}
+                        isPortrait
+                      />
+                    )
+                  }
+                  return null
+                })}
               </>
-            )}
+            ) : null}
           </div>
         ))}
         {chatProcessing && toolStatusMessage ? (
@@ -122,22 +138,38 @@ export const ChatLog = ({ isPortrait }: { isPortrait?: boolean }) => {
                 message={msg.content}
                 characterName={characterName}
               />
-            ) : (
+            ) : Array.isArray(msg.content) ? (
               <>
-                {msg.content?.[0]?.text ? (
-                  <Chat
-                    role={msg.role}
-                    message={msg.content[0].text}
-                    characterName={characterName}
-                  />
-                ) : null}
-                <ChatImage
-                  role={msg.role}
-                  imageUrl={msg.content ? msg.content[1].image : ''}
-                  characterName={characterName}
-                />
+                {msg.content.map((block, j) => {
+                  if (block.type === 'text' && block.text) {
+                    return (
+                      <Chat
+                        key={j}
+                        role={msg.role}
+                        message={block.text}
+                        characterName={characterName}
+                      />
+                    )
+                  }
+                  if (block.type === 'image' && block.image) {
+                    const src =
+                      block.image.startsWith('data:') ||
+                      block.image.startsWith('http')
+                        ? block.image
+                        : `data:image/png;base64,${block.image}`
+                    return (
+                      <ChatImage
+                        key={j}
+                        role={msg.role}
+                        imageUrl={src}
+                        characterName={characterName}
+                      />
+                    )
+                  }
+                  return null
+                })}
               </>
-            )}
+            ) : null}
           </div>
         )
       })}
@@ -266,6 +298,21 @@ const parseLinks = (text: string): React.ReactNode[] => {
   return parts.length > 0 ? parts : [text]
 }
 
+// テキスト内の画像URLを抽出する
+const IMAGE_URL_PATTERN =
+  /https?:\/\/[^\s"'<>]+\.(?:png|jpg|jpeg|gif|webp)(?:\?[^\s"'<>]*)?/gi
+
+const extractImageUrls = (
+  text: string
+): { cleanText: string; urls: string[] } => {
+  const urls: string[] = []
+  const cleanText = text.replace(IMAGE_URL_PATTERN, (match) => {
+    urls.push(match)
+    return ''
+  })
+  return { cleanText: cleanText.replace(/\s+/g, ' ').trim(), urls }
+}
+
 const Chat = ({
   role,
   message,
@@ -277,7 +324,11 @@ const Chat = ({
   characterName: string
   isPortrait?: boolean
 }) => {
-  const processedMessage = message
+  // 画像URLをテキストから抽出
+  const { cleanText: textWithoutImages, urls: imageUrls } =
+    extractImageUrls(message)
+
+  const processedMessage = textWithoutImages
     .replace(/\[[^\]]*\]/g, '')
     .replace(/\{[^}]*\}/g, '')
     .replace(/\s+/g, ' ')
@@ -311,13 +362,61 @@ const Chat = ({
             {role !== 'user' ? characterName || 'CHARACTER' : 'YOU'}
           </div>
           <div className="px-6 py-4 bg-white/70 dark:bg-black/50 backdrop-blur-sm rounded-b-lg">
-            <div className={`font-bold whitespace-pre-wrap ${roleText}`}>
-              {messageContent}
-            </div>
+            {processedMessage && (
+              <div className={`font-bold whitespace-pre-wrap ${roleText}`}>
+                {messageContent}
+              </div>
+            )}
+            {imageUrls.map((url, idx) => (
+              <ExpandableImage
+                key={idx}
+                src={url}
+                alt={`Generated image ${idx + 1}`}
+                className="mt-2"
+              />
+            ))}
           </div>
         </>
       )}
     </div>
+  )
+}
+
+const ExpandableImage = ({
+  src,
+  alt,
+  className = '',
+}: {
+  src: string
+  alt: string
+  className?: string
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+  return (
+    <>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={src}
+        alt={alt}
+        className={`rounded-lg cursor-pointer hover:opacity-80 transition-opacity ${className}`}
+        style={{ maxWidth: '100%', maxHeight: 400 }}
+        onClick={() => setIsExpanded(true)}
+      />
+      {isExpanded && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+          onClick={() => setIsExpanded(false)}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={src}
+            alt={alt}
+            className="max-w-[90vw] max-h-[90vh] rounded-lg shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
+    </>
   )
 }
 
@@ -339,13 +438,7 @@ const ChatImage = ({
         isPortrait ? 'my-1' : `mx-auto ml-0 md:ml-10 lg:ml-20 my-1 ${offsetX}`
       }
     >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={imageUrl}
-        alt="Sent image"
-        className="rounded-lg"
-        style={{ maxWidth: 120, maxHeight: 120 }}
-      />
+      <ExpandableImage src={imageUrl} alt="Sent image" />
     </div>
   )
 }

--- a/src/components/settings/based.tsx
+++ b/src/components/settings/based.tsx
@@ -255,7 +255,9 @@ const Based = () => {
                   max={100}
                   value={ttsVolume}
                   onChange={(e) =>
-                    settingsStore.setState({ ttsVolume: Number(e.target.value) })
+                    settingsStore.setState({
+                      ttsVolume: Number(e.target.value),
+                    })
                   }
                   className="flex-1 accent-secondary"
                 />

--- a/src/components/settings/log.tsx
+++ b/src/components/settings/log.tsx
@@ -76,7 +76,15 @@ const Log = () => {
                     ></input>
                   ) : (
                     <Image
-                      src={value.content[1].image}
+                      src={
+                        Array.isArray(value.content)
+                          ? (
+                              value.content.find((b) => b.type === 'image') as
+                                | { type: 'image'; image: string }
+                                | undefined
+                            )?.image || ''
+                          : ''
+                      }
                       alt="画像"
                       width={500}
                       height={500}

--- a/src/features/chat/agentCoreChat.ts
+++ b/src/features/chat/agentCoreChat.ts
@@ -1,6 +1,8 @@
 import settingsStore from '@/features/stores/settings'
 
-export type ToolEvent = { type: 'tool_start' | 'tool_end'; tool?: string }
+export type ToolEvent =
+  | { type: 'tool_start' | 'tool_end'; tool?: string }
+  | { type: 'image'; url: string }
 export type StreamChunk = string | ToolEvent
 
 /**

--- a/src/features/chat/handlers.ts
+++ b/src/features/chat/handlers.ts
@@ -93,6 +93,9 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   diary_agent: '日記を作成中',
   intro_agent: '自己紹介を準備中',
   twitter_agent: 'Twitterを操作中',
+  execute_python: 'コードを実行中',
+  get_aws_cost: 'AWSコストを取得中',
+  skills: 'スキルを読み込み中',
 }
 
 const TOOL_STATUS_ID = 'tool-status'
@@ -538,6 +541,15 @@ export const processAIResponse = async (
             })
           } else if (toolEvent.type === 'tool_end') {
             removeToolStatus()
+          } else if (toolEvent.type === 'image' && 'url' in toolEvent) {
+            // Code Interpreter からのグラフ画像イベント（S3署名付きURL）
+            const imgEvent = toolEvent as ToolEvent & { url: string }
+            const imageId = generateMessageId()
+            homeStore.getState().upsertMessage({
+              id: imageId,
+              role: 'assistant',
+              content: [{ type: 'image', image: imgEvent.url }],
+            })
           }
         } else {
           // テキストチャンクの処理（既存ロジック）

--- a/src/features/messages/messageSelectors.ts
+++ b/src/features/messages/messageSelectors.ts
@@ -1,5 +1,21 @@
-import { Message } from './messages'
+import { ContentBlock, Message } from './messages'
 import settingsStore from '@/features/stores/settings'
+
+/** ContentBlock 配列からテキストを抽出 */
+function getTextFromBlocks(blocks: ContentBlock[]): string {
+  const textBlock = blocks.find(
+    (b): b is ContentBlock & { type: 'text' } => b.type === 'text'
+  )
+  return textBlock?.text || ''
+}
+
+/** ContentBlock 配列から画像URLを抽出 */
+function getImageFromBlocks(blocks: ContentBlock[]): string {
+  const imgBlock = blocks.find(
+    (b): b is ContentBlock & { type: 'image' } => b.type === 'image'
+  )
+  return imgBlock?.image || ''
+}
 
 export const messageSelectors = {
   // テキストまたは画像を含むメッセージのみを取得（tool-statusは除外）
@@ -43,19 +59,25 @@ export const messageSelectors = {
         // 最後のメッセージだけそのまま利用する（= 最後のメッセージだけマルチモーダルの対象となる）
         const isLastMessage = index === messages.length - 1
         const messageText = Array.isArray(message.content)
-          ? message.content[0].text
+          ? getTextFromBlocks(message.content)
           : message.content || ''
 
         let content: Message['content']
         if (includeTimestamp) {
-          content = message.timestamp
+          const textWithTimestamp = message.timestamp
             ? `[${message.timestamp}] ${messageText}`
             : messageText
           if (isLastMessage && Array.isArray(message.content)) {
-            content = [
-              { type: 'text', text: content },
-              { type: 'image', image: message.content[1].image },
+            const imageUrl = getImageFromBlocks(message.content)
+            const blocks: ContentBlock[] = [
+              { type: 'text', text: textWithTimestamp },
             ]
+            if (imageUrl) {
+              blocks.push({ type: 'image', image: imageUrl })
+            }
+            content = blocks
+          } else {
+            content = textWithTimestamp
           }
         } else {
           content = isLastMessage ? message.content : messageText
@@ -76,13 +98,9 @@ export const messageSelectors = {
     let lastImageUrl = ''
     return messages
       .reduce((acc: Message[], item: Message) => {
-        if (
-          item.content &&
-          typeof item.content != 'string' &&
-          item.content[0] &&
-          item.content[1]
-        ) {
-          lastImageUrl = item.content[1].image
+        if (item.content && Array.isArray(item.content)) {
+          const imgUrl = getImageFromBlocks(item.content)
+          if (imgUrl) lastImageUrl = imgUrl
         }
 
         const lastItem = acc[acc.length - 1]
@@ -93,32 +111,31 @@ export const messageSelectors = {
           item.id !== undefined &&
           lastItem.id === item.id
         ) {
-          if (typeof item.content !== 'string' && item.content?.[0]?.text) {
+          const itemText = Array.isArray(item.content)
+            ? getTextFromBlocks(item.content)
+            : typeof item.content === 'string'
+              ? item.content
+              : ''
+          if (itemText) {
             const currentText =
               typeof lastItem.content === 'string'
                 ? lastItem.content
-                : lastItem.content?.[0]?.text || ''
+                : Array.isArray(lastItem.content)
+                  ? getTextFromBlocks(lastItem.content)
+                  : ''
             if (Array.isArray(lastItem.content)) {
-              lastItem.content[0].text =
-                currentText + ' ' + item.content[0].text
+              const textBlock = lastItem.content.find((b) => b.type === 'text')
+              if (textBlock && textBlock.type === 'text') {
+                textBlock.text = currentText + ' ' + itemText
+              }
             } else {
-              lastItem.content = currentText + ' ' + item.content[0].text
-            }
-          } else if (typeof item.content === 'string') {
-            const currentText =
-              typeof lastItem.content === 'string'
-                ? lastItem.content
-                : lastItem.content?.[0]?.text || ''
-            if (Array.isArray(lastItem.content)) {
-              lastItem.content[0].text = currentText + ' ' + item.content
-            } else {
-              lastItem.content = currentText + ' ' + item.content
+              lastItem.content = currentText + ' ' + itemText
             }
           }
         } else {
           const text = item.content
-            ? typeof item.content != 'string'
-              ? item.content[0].text
+            ? Array.isArray(item.content)
+              ? getTextFromBlocks(item.content)
               : item.content
             : ''
           if (lastImageUrl != '') {
@@ -148,7 +165,7 @@ export const messageSelectors = {
           ? ''
           : typeof message.content === 'string'
             ? message.content
-            : message.content[0].text,
+            : getTextFromBlocks(message.content),
     }))
   },
 
@@ -164,14 +181,14 @@ export const messageSelectors = {
     if (message.content && Array.isArray(message.content)) {
       return {
         ...message,
-        content: message.content.map((content: any) => {
-          if (content.type === 'image') {
+        content: message.content.map((block) => {
+          if (block.type === 'image') {
             return {
               type: 'image',
               image: '[image data omitted]',
             }
           }
-          return content
+          return block
         }),
       }
     }

--- a/src/features/messages/messages.ts
+++ b/src/features/messages/messages.ts
@@ -1,9 +1,11 @@
+export type ContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'image'; image: string }
+
 export type Message = {
   id?: string
   role: string // "assistant" | "system" | "user";
-  content?:
-    | string
-    | [{ type: 'text'; text: string }, { type: 'image'; image: string }] // マルチモーダル拡張
+  content?: string | ContentBlock[]
   audio?: { id: string }
   timestamp?: string
 }

--- a/src/pages/api/services/utils.ts
+++ b/src/pages/api/services/utils.ts
@@ -47,25 +47,18 @@ function modifyAnthropicMessages(messages: Message[]): Message[] {
 export function consolidateMessages(messages: Message[]) {
   const consolidated: Message[] = []
   let lastRole: string | null = null
-  let combinedContent:
-    | string
-    | [
-        {
-          type: 'text'
-          text: string
-        },
-        {
-          type: 'image'
-          image: string
-        },
-      ]
+  let combinedContent: Message['content']
 
   messages.forEach((message, index) => {
     if (message.role === lastRole) {
       if (typeof combinedContent === 'string') {
         combinedContent += '\n' + message.content
-      } else {
-        combinedContent[0].text += '\n' + message.content
+      } else if (Array.isArray(combinedContent)) {
+        const textBlock = combinedContent.find((b) => b.type === 'text')
+        if (textBlock && textBlock.type === 'text') {
+          textBlock.text +=
+            '\n' + (typeof message.content === 'string' ? message.content : '')
+        }
       }
     } else {
       if (lastRole !== null) {


### PR DESCRIPTION
## 概要
AgentCore Code Interpreterを統合し、サンドボックスでのPythonコード実行と画像生成に対応。初回ユースケースとしてAWSコスト可視化を実装。

## 変更点

### バックエンド（agentcore/）
- `execute_python` ツール: Code Interpreterサンドボックスでのコード実行、matplotlib画像の自動キャプチャ→S3アップロード→署名付きURL返却
- `get_aws_cost` ツール: Cost Explorer APIからコストデータ取得（ランタイム側で直接実行）
- `AgentSkills` プラグイン統合: `skills/aws-cost/SKILL.md` によるスキル管理
- boto3クライアントの事前初期化（レイテンシ改善）

### インフラ（infra/）
- S3バケット `tonari-codeinterpreter-outputs-{account}`（1日ライフサイクル）
- IAM: Code Interpreter / Cost Explorer / S3 権限追加

### フロントエンド（src/）
- `ContentBlock` 型の柔軟化（テキスト・画像の可変長配列対応）
- テキスト内のS3画像URL自動検出→インライン表示
- `ExpandableImage`: クリックで拡大モーダル表示
- SSE `image` イベント対応（URL方式）
- ツールステータス表示（`execute_python`, `get_aws_cost`, `skills`）